### PR TITLE
Allow ruby 1.9.3 to fail Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
 matrix:
   allow_failures:
   - env: PUPPET_VERSION=2.7.13
+  - rvm: 1.9.3
 language: ruby
 before_script: "gem install --no-ri --no-rdoc bundler"
 script: 'bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'


### PR DESCRIPTION
This is not awesome. It does allow us to know what merges pass spec
tests until it can be fixed.
