### PR TITLE
Add support for Suse 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This module has been tested to work on the following systems using Puppet v3 and
 
  * EL 5
  * EL 6
+ * Suse 11
  * Solaris 10
 
 ===
@@ -131,15 +132,63 @@ Content for PAM session. If undef, parameter is set based on the OS version.
 
 - *Default*: undef, default is set based on OS version
 
+common_auth_file
+----------------
+Path to common-auth. Used on Suse.
+
+- *Default*: '/etc/pam.d/common-auth'
+
+common_auth_pc_file
+-------------------
+Path to common-auth-pc. Used on Suse.
+
+- *Default*: '/etc/pam.d/common-auth-pc'
+
+common_account_file
+----------------
+Path to common-account. Used on Suse.
+
+- *Default*: '/etc/pam.d/common-account'
+
+common_account_pc_file
+-------------------
+Path to common-account-pc. Used on Suse.
+
+- *Default*: '/etc/pam.d/common-account-pc'
+
+common_password_file
+----------------
+Path to common-password. Used on Suse.
+
+- *Default*: '/etc/pam.d/common-password'
+
+common_password_pc_file
+-------------------
+Path to common-password-pc. Used on Suse.
+
+- *Default*: '/etc/pam.d/common-password-pc'
+
+common_session_file
+----------------
+Path to common-session. Used on Suse.
+
+- *Default*: '/etc/pam.d/common-session'
+
+common_session_pc_file
+-------------------
+Path to common-session-pc. Used on Suse.
+
+- *Default*: '/etc/pam.d/common-session-pc'
+
 system_auth_file
 ----------------
-Path to system-auth.
+Path to system-auth. Used on RedHat.
 
 - *Default*: '/etc/pam.d/system-auth'
 
 system_auth_ac_file
 -------------------
-Path to system-auth-ac
+Path to system-auth-ac. Used on RedHat.
 
 - *Default*: '/etc/pam.d/system-auth-ac'
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -35,6 +35,22 @@ describe 'pam' do
       end
     end
 
+    context 'with class defaults on osfamily suse with lsbmajdistrelease 11' do
+      let :facts do
+        {
+          :osfamily          => 'Suse',
+          :lsbmajdistrelease => '11',
+        }
+      end
+
+      it do
+        should contain_package('pam_package').with({
+          'ensure' => 'installed',
+          'name'   => 'pam',
+        })
+      end
+    end
+
     context 'with specifying package_name on valid platform' do
       let :facts do
         {
@@ -118,6 +134,93 @@ describe 'pam' do
       should contain_file('pam_system_auth').with({
         'ensure' => 'symlink',
         'path'   => '/etc/pam.d/system-auth',
+        'owner'  => 'root',
+        'group'  => 'root',
+      })
+
+      should contain_file('pam_d_login').with({
+        'ensure' => 'file',
+        'path'   => '/etc/pam.d/login',
+        'owner'  => 'root',
+        'group'  => 'root',
+        'mode'   => '0644',
+      })
+
+      should contain_file('pam_d_sshd').with({
+        'ensure' => 'file',
+        'path'   => '/etc/pam.d/sshd',
+        'owner'  => 'root',
+        'group'  => 'root',
+        'mode'   => '0644',
+      })
+      end
+    end
+
+    context 'defaults on osfamily suse with lsbmajdistrelease 11' do
+      let :facts do
+        {
+          :osfamily          => 'Suse',
+          :lsbmajdistrelease => '11',
+        }
+      end
+
+      it do
+        should contain_file('pam_common_auth_pc').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/pam.d/common-auth-pc',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+        })
+
+      should contain_file('pam_common_auth').with({
+        'ensure' => 'symlink',
+        'path'   => '/etc/pam.d/common-auth',
+        'owner'  => 'root',
+        'group'  => 'root',
+      })
+
+      should contain_file('pam_common_account_pc').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/pam.d/common-account-pc',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+        })
+
+      should contain_file('pam_common_account').with({
+        'ensure' => 'symlink',
+        'path'   => '/etc/pam.d/common-account',
+        'owner'  => 'root',
+        'group'  => 'root',
+      })
+
+      should contain_file('pam_common_password_pc').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/pam.d/common-password-pc',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+        })
+
+      should contain_file('pam_common_password').with({
+        'ensure' => 'symlink',
+        'path'   => '/etc/pam.d/common-password',
+        'owner'  => 'root',
+        'group'  => 'root',
+      })
+
+      should contain_file('pam_common_session_pc').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/pam.d/common-session-pc',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+        })
+
+      should contain_file('pam_common_session').with({
+        'ensure' => 'symlink',
+        'path'   => '/etc/pam.d/common-session',
         'owner'  => 'root',
         'group'  => 'root',
       })

--- a/templates/common-account-pc.erb
+++ b/templates/common-account-pc.erb
@@ -1,0 +1,5 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+<% my_pam_account_lines.each do |account_line| -%>
+<%= account_line %>
+<% end -%>

--- a/templates/common-auth-pc.erb
+++ b/templates/common-auth-pc.erb
@@ -1,0 +1,5 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+<% my_pam_auth_lines.each do |auth_line| -%>
+<%= auth_line %>
+<% end -%>

--- a/templates/common-password-pc.erb
+++ b/templates/common-password-pc.erb
@@ -1,0 +1,5 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+<% my_pam_password_lines.each do |password_line| -%>
+<%= password_line %>
+<% end -%>

--- a/templates/common-session-pc.erb
+++ b/templates/common-session-pc.erb
@@ -1,0 +1,5 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+<% my_pam_session_lines.each do |session_line| -%>
+<%= session_line %>
+<% end -%>

--- a/templates/login.suse11.erb
+++ b/templates/login.suse11.erb
@@ -1,0 +1,12 @@
+#%PAM-1.0
+auth     requisite      pam_nologin.so
+auth     [user_unknown=ignore success=ok ignore=ignore auth_err=die default=bad]        pam_securetty.so
+auth     include        common-auth
+account  include        common-account
+account  required       pam_access.so
+password include        common-password
+session  required       pam_loginuid.so
+session  include        common-session
+session  required       pam_lastlog.so  nowtmp
+session  optional       pam_mail.so standard
+session  optional       pam_ck_connector.so

--- a/templates/sshd.suse11.erb
+++ b/templates/sshd.suse11.erb
@@ -1,0 +1,9 @@
+#%PAM-1.0
+auth     requisite      pam_nologin.so
+auth     include        common-auth
+account  required       pam_access.so
+account  requisite      pam_nologin.so
+account  include        common-account
+password include        common-password
+session  required       pam_loginuid.so
+session  include        common-session


### PR DESCRIPTION
A couple new parameters introduced, since Suse use four different files in /etc/pam.d instead of a single system-auth file.
