### PR TITLE
Include_class is deprecated. Use contain_class instead.

### DIFF
--- a/spec/classes/accesslogin_spec.rb
+++ b/spec/classes/accesslogin_spec.rb
@@ -9,7 +9,7 @@ describe 'pam::accesslogin' do
         }
       end
       it do
-        should include_class('pam')
+        should contain_class('pam')
         should contain_file('access_conf').with({
           'ensure' => 'file',
           'path'   => '/etc/security/access.conf',
@@ -42,7 +42,7 @@ describe 'pam::accesslogin' do
           'class {"pam": allowed_users => ["foo","bar"] }'
       end
       it do
-        should include_class('pam')
+        should contain_class('pam')
         should contain_file('access_conf').with({
           'ensure' => 'file',
           'path'   => '/etc/security/access.conf',
@@ -83,7 +83,7 @@ describe 'pam::accesslogin' do
       end
 
       it do
-        should include_class('pam')
+        should contain_class('pam')
         should contain_file('access_conf').with({
           'ensure' => 'file',
           'path'   => '/custom/security/access.conf',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -11,7 +11,7 @@ describe 'pam' do
 
       it 'should fail' do
         expect {
-          should include_class('pam')
+          should contain_class('pam')
         }.to raise_error(Puppet::Error,/Pam is only supported on EL 5 and 6. Your lsbmajdistrelease is identified as <4>./)
       end
     end
@@ -25,7 +25,7 @@ describe 'pam' do
 
       it 'should fail' do
         expect {
-          should include_class('pam')
+          should contain_class('pam')
         }.to raise_error(Puppet::Error,/Pam is only supported on Suse 10 and 11. Your lsbmajdistrelease is identified as <8>./)
       end
     end
@@ -40,7 +40,7 @@ describe 'pam' do
 
       it 'should fail' do
         expect {
-          should include_class('pam')
+          should contain_class('pam')
         }.to raise_error(Puppet::Error,/Pam is only supported on lsbdistid Ubuntu of the Debian osfamily. Your lsbdistid is <Debian>./)
       end
     end
@@ -55,7 +55,7 @@ describe 'pam' do
 
       it 'should fail' do
         expect {
-          should include_class('pam')
+          should contain_class('pam')
         }.to raise_error(Puppet::Error,/Pam is only supported on Ubuntu 12.04. Your lsbdistrelease is identified as <10.04>./)
       end
     end
@@ -197,7 +197,7 @@ describe 'pam' do
 
       it 'should fail' do
         expect {
-          should include_class('pam')
+          should contain_class('pam')
         }.to raise_error(Puppet::Error)
       end
 
@@ -1129,8 +1129,8 @@ session required        pam_unix_session.so.1
         }
       end
 
-      it { should include_class('pam::accesslogin') }
-      it { should include_class('pam::limits') }
+      it { should contain_class('pam::accesslogin') }
+      it { should contain_class('pam::limits') }
 
       it {
         should contain_package('pam_package').with({
@@ -1309,7 +1309,7 @@ session required  pam_unix.so
 
       it 'should fail' do
         expect {
-          should include_class('pam')
+          should contain_class('pam')
         }.to raise_error(Puppet::Error,/Pam is only supported with vas_major_version 3 or 4/)
       end
     end
@@ -1330,7 +1330,7 @@ session required  pam_unix.so
 
       it 'should fail' do
         expect {
-          should include_class('pam')
+          should contain_class('pam')
         }.to raise_error(Puppet::Error,/Pam is only supported with vas_major_version 3 or 4/)
       end
     end

--- a/spec/classes/limits_spec.rb
+++ b/spec/classes/limits_spec.rb
@@ -9,7 +9,7 @@ describe 'pam::limits' do
         }
       end
       it {
-        should include_class('pam')
+        should contain_class('pam')
         should contain_file('limits_conf').with({
           'ensure' => 'file',
           'path'   => '/etc/security/limits.conf',
@@ -33,7 +33,7 @@ describe 'pam::limits' do
       end
 
       it {
-        should include_class('pam')
+        should contain_class('pam')
         should contain_file('limits_conf').with({
           'ensure' => 'file',
           'path'   => '/custom/security/limits.conf',

--- a/spec/defines/limits/fragment_spec.rb
+++ b/spec/defines/limits/fragment_spec.rb
@@ -13,8 +13,8 @@ describe 'pam::limits::fragment' do
       }
     }
 
-    it { should include_class('pam') }
-    it { should include_class('pam::limits') }
+    it { should contain_class('pam') }
+    it { should contain_class('pam::limits') }
 
     it {
       should contain_file('/etc/security/limits.d/80-nproc.conf').with({
@@ -40,8 +40,8 @@ describe 'pam::limits::fragment' do
       }
     }
 
-    it { should include_class('pam') }
-    it { should include_class('pam::limits') }
+    it { should contain_class('pam') }
+    it { should contain_class('pam::limits') }
 
     it {
       should contain_file('/etc/security/limits.d/80-nproc.conf').with({
@@ -76,8 +76,8 @@ root soft nproc unlimited
       }
     }
 
-    it { should include_class('pam') }
-    it { should include_class('pam::limits') }
+    it { should contain_class('pam') }
+    it { should contain_class('pam::limits') }
 
     it {
       should contain_file('/etc/security/limits.d/80-nproc.conf').with({
@@ -107,7 +107,7 @@ root soft nproc unlimited
 
     it 'should fail' do
       expect {
-        should include_class('pam::limits')
+        should contain_class('pam::limits')
       }.to raise_error(Puppet::Error,/pam::limits::fragment must specify source or list./)
     end
   end


### PR DESCRIPTION
puppet-rspec deprecated include_class, this commit changes all usages of include_class to use contain_class.
