### PR TITLE
Refactored pam::service definition

### DIFF
--- a/lib/puppet/parser/functions/validate_pam_directives.rb
+++ b/lib/puppet/parser/functions/validate_pam_directives.rb
@@ -1,0 +1,40 @@
+module Puppet::Parser::Functions
+  newfunction(:validate_pam_directives, :doc => <<-'ENDHEREDOC') do |args|
+    Validate that all values are arrays with hashes with all the keys required for
+    a pam directive.
+
+    Abort catalog
+    compilation if any value fails this check.
+    ENDHEREDOC
+
+    unless args.length == 1 then
+      raise Puppet::ParseError, ("validate_pam_directive(): wrong number of arguments (#{args.length}; Requires 1 argument)")
+    end
+
+    directives = args[0]
+    unless directives.is_a? Array
+      raise Puppet::ParseError, ("Value passed to validate_pam_directives() must be a Array, got #{hash.class}")
+    end
+
+
+    directives.each_index do |directive_index|
+    directive = directives.at directive_index
+
+      unless directive.is_a? Hash
+      raise Puppet::ParseError, ("All values in the directives array must be a hash. Value at index #{directive_index} is a #{directive.class}")
+    end
+      unless directive.has_key? 'control'
+        raise Puppet::ParseError, ("PAM directive #{directive} (Index: #{directive_index}) does not include a value for 'control'")
+      end
+
+      unless directive.has_key? 'module-path'
+        raise Puppet::ParseError, ("PAM directive #{directive} (Index: #{directive_index}) does not include a value for 'module-path'")
+      end
+
+      unless directive.has_key? 'module-arguments'
+        raise Puppet::ParseError, ("PAM directive #{directive} (Index: #{directive_index}) does not include a value for 'module-arguments'")
+      end
+    end
+
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,7 +3,7 @@
 # This module manages bits around PAM.
 #
 class pam (
-  $allowed_users                       = 'root',
+  $allowed_users                       = ['root'],
   $ensure_vas                          = 'absent',
   $package_name                        = undef,
   $pam_conf_file                       = '/etc/pam.conf',

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,17 +2,65 @@
 #
 # Manage PAM file for a specifc service
 #
+# === Parameters
+#
+# [*auth_directives*]
+#   An array of hashes with directives for the auth type
+#   The hash must include the following keys
+#     - control
+#     - module-path
+#     - module-arguments
+#
+# [*account_directives*]
+#   An array of hashes with directives for the account type
+#   The hash must include the following keys
+#     - control
+#     - module-path
+#     - module-arguments
+#
+# [*session_directives*]
+#   An array of hashes with directives for the session type
+#   The hash must include the following keys
+#     - control
+#     - module-path
+#     - module-arguments
+#
+# [*password_directives*]
+#   An array of hashes with directives for the password type
+#   The hash must include the following keys
+#     - control
+#     - module-path
+#     - module-arguments
+#
+# === Examples
+# pam::service {'ftp':
+#    auth_directives => [{'control' => 'required',
+#                         'module-path' => 'pam_nologin.so'
+#                         'module-arguments' => 'no_warn'}]
+# }
+#
+#
+
+
 define pam::service (
   $pam_config_dir = '/etc/pam.d',
-  $content        = undef,
+  $auth_directives = [],
+  $account_directives = [],
+  $session_directives = [],
+  $password_directives = []
 ) {
 
   include pam
 
+  validate_pam_directives($auth_directives)
+  validate_pam_directives($account_directives)
+  validate_pam_directives($session_directives)
+  validate_pam_directives($password_directives)
+
   file { "pam.d-service-${name}":
     ensure  => file,
     path    => "${pam_config_dir}/${name}",
-    content => $content,
+    content => template('pam/pam_service.erb'),
     owner   => 'root',
     group   => 'root',
     mode    => '0644',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -165,7 +165,12 @@ describe 'pam' do
   describe 'config files' do
 
     context 'with specifying services param' do
-      let (:params) { {:services => { 'testservice' => { 'content' => 'foo' } } } }
+
+      service_settings = {"auth_directives" => [{'control' => 'required',
+                         'module-path' => 'pam_nologin.so',
+                         'module-arguments' => 'no_warn'}]}
+
+      let (:params) { {:services => { 'testservice' => service_settings } } }
       let :facts do
         {
           :osfamily          => 'Suse',
@@ -183,7 +188,7 @@ describe 'pam' do
         })
       }
 
-      it { should contain_file('pam.d-service-testservice').with_content('foo') }
+      it { should contain_file('pam.d-service-testservice').with_content(/auth required pam_nologin.so no_warn/) }
     end
 
     context 'with specifying services param as invalid type (non-hash)' do

--- a/spec/defines/service_spec.rb
+++ b/spec/defines/service_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+describe 'pam::service' do
+  context 'test' do
+    let(:title) { 'ftp' }
+    let(:params) {
+      {:auth_directives => [{'control' => 'required',
+                         'module-path' => 'pam_nologin.so',
+                         'module-arguments' => 'no_warn'}]}
+    }
+    let(:facts) {
+      {
+        :osfamily          => 'RedHat',
+        :lsbmajdistrelease => '6',
+      }
+    }
+
+    it { should contain_class('pam') }
+
+    it { should contain_file('pam.d-service-ftp').with({
+        'ensure' => 'file',
+        'path'   => '/etc/pam.d/ftp',
+        'owner'  => 'root',
+        'group'  => 'root',
+        'mode'   => '0644',
+      })
+    }
+    it { should contain_file('pam.d-service-ftp').with_content(/auth required pam_nologin.so no_warn/) }
+  end
+end

--- a/templates/pam_service.erb
+++ b/templates/pam_service.erb
@@ -1,0 +1,23 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+#%PAM-1.0
+
+# Auth
+<% auth_directives.each do |auth_directive| -%>
+auth <%= auth_directive['control'] %> <%= auth_directive['module-path'] %> <%= auth_directive['module-arguments'] %>
+<% end -%>
+
+# Account
+<% account_directives.each do |account_directive| -%>
+account <%= account_directive['control'] %> <%= account_directive['module-path'] %> <%= account_directive['module-arguments'] %>
+<% end -%>
+
+# Session
+<% session_directives.each do |session_directive| -%>
+password <%= session_directive['control'] %> <%= session_directive['module-path'] %> <%= session_directive['module-arguments'] %>
+<% end -%>
+
+# Password
+<% password_directives.each do |password_directive| -%>
+session <%= password_directive['control'] %> <%= password_directive['module-path'] %> <%= password_directive['module-arguments'] %>
+<% end -%>


### PR DESCRIPTION
The pam::service definition used to only have a free text 'content' parameter to define a pam service.
Now it takes an array of hashes for every type.

This breaks backwards compatibility, but I think this is a more sane way to define a pam service.