### PR TITLE
Manage limits.d directory

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,5 +4,8 @@ fixtures:
       repo: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
       ref: '3.2.0'
     'nsswitch': 'git://github.com/ghoneycutt/puppet-module-nsswitch.git'
+    'common':
+      repo: 'git://github.com/ghoneycutt/puppet-module-common.git'
+      ref: 'v1.0.2'
   symlinks:
     pam: "#{source_dir}"

--- a/Modulefile
+++ b/Modulefile
@@ -7,5 +7,6 @@ summary 'Manage PAM'
 description 'Manages PAM, including specifying users and groups in access.conf, limits.conf, and limits fragments'
 project_page 'https://github.com/ghoneycutt/puppet-module-pam'
 
+dependency 'ghoneycutt/common',   '>= 1.0.2'
 dependency 'ghoneycutt/nsswitch', '>= 0.0.1'
 dependency 'puppetlabs/stdlib',   '>= 3.2.0'

--- a/manifests/limits.pp
+++ b/manifests/limits.pp
@@ -7,7 +7,15 @@ class pam::limits (
   $limits_d_dir = '/etc/security/limits.d',
 ) {
 
+  # validate params
+  validate_absolute_path($config_file)
+  validate_absolute_path($limits_d_dir)
+
   include pam
+
+  # ensure target exists
+  include common
+  common::mkdir_p { $limits_d_dir: }
 
   file { 'limits_d':
     ensure  => directory,

--- a/spec/classes/limits_spec.rb
+++ b/spec/classes/limits_spec.rb
@@ -48,6 +48,24 @@ describe 'pam::limits' do
         })
       }
     end
+    context 'with config_file specified as an invalid path' do
+      let(:facts) do
+        {
+          :osfamily          => 'RedHat',
+          :lsbmajdistrelease => '5',
+        }
+      end
+
+      let(:params) do
+        { :config_file => 'custom/security/limits.conf' }
+      end
+
+      it 'should fail' do
+        expect {
+          should contain_class('pam::limits')
+        }.to raise_error(Puppet::Error,/not an absolute path/)
+      end
+    end
   end
   describe 'limits.d' do
     context 'ensure directory exists with default values for params on a supported platform' do
@@ -85,6 +103,7 @@ describe 'pam::limits' do
       end
 
       it { should contain_class('pam') }
+      it { should contain_class('common') }
 
       it {
         should contain_file('limits_d').with({
@@ -96,6 +115,25 @@ describe 'pam::limits' do
           'require' => [ 'Package[pam]', 'Package[util-linux]' ],
         })
       }
+    end
+
+    context 'with limits_d_dir specified as an invalid path' do
+      let(:facts) do
+        {
+          :osfamily          => 'RedHat',
+          :lsbmajdistrelease => '5',
+        }
+      end
+
+      let(:params) do
+        { :limits_d_dir => 'custom/security/limits.d' }
+      end
+
+      it 'should fail' do
+        expect {
+          should contain_class('pam::limits')
+        }.to raise_error(Puppet::Error,/not an absolute path/)
+      end
     end
   end
 end


### PR DESCRIPTION
This is required in order to use individual limits files on Suse 11. For some reason this directory is not created by the package on that platform.
