### PR TITLE
Made it possible to specify origins in access.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,30 @@ This module has been tested to work on the following systems using Puppet v3 wit
 
 allowed_users
 -------------
-String, hash or array of users allowed to log in.
+Hash of strings and arrays to configure users and origins in access.conf.
 
 - *Default*: root
 
 # Hiera example for allowed_users
 <pre>
 pam::allowed_users:
+  'username':
   'username1':
-    - 'crond'
+    - 'cron'
     - 'tty0'
   'username2': 'tty1'
-   - 'username'
+</pre>
+
+This would create /etc/security/access.conf with content.
+<pre>
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+#
+
+#allow only the groups listed
++ : username : ALL
++ : username1 : cron tty0
++ : username2 : tty1
 </pre>
 
 limits_fragments

--- a/spec/classes/accesslogin_spec.rb
+++ b/spec/classes/accesslogin_spec.rb
@@ -77,7 +77,7 @@ describe 'pam::accesslogin' do
       }
     end
 
-    context 'with allowed users set to hash with a string value' do
+    context 'with hash entry containing string values' do
       let(:facts) do
         {
           :osfamily          => 'RedHat',
@@ -91,7 +91,7 @@ describe 'pam::accesslogin' do
       it { should contain_file('access_conf').with_content(/^\+ : username2 : tty0$/)}
     end
 
-    context 'with allowed users set to hash with a hash of arrays' do
+    context 'with hash entry containing array of values' do
       let(:facts) do
         {
           :osfamily          => 'RedHat',
@@ -104,7 +104,7 @@ describe 'pam::accesslogin' do
       it { should contain_file('access_conf').with_content(/^\+ : username : cron tty0$/)}
     end
 
-    context 'with allowed users set as a string' do
+    context 'with hash entry containing no value should default to "ALL"' do
       let(:facts) do
         {
           :osfamily          => 'RedHat',
@@ -112,9 +112,26 @@ describe 'pam::accesslogin' do
         }
       end
       let(:pre_condition) do
-          'class {"pam": allowed_users => "username"}'
+          'class {"pam": allowed_users => {"username" => {} }}'
       end
       it { should contain_file('access_conf').with_content(/^\+ : username : ALL$/)}
+    end
+    
+    context 'with hash entries containing string, array and empty hash' do
+      let(:facts) do
+        {
+          :osfamily          => 'RedHat',
+          :lsbmajdistrelease => '5',
+        }
+      end
+      let(:pre_condition) do
+          'class {"pam": allowed_users => {"username" => "tty5", "username1" => ["cron", "tty0"], "username2" => "cron", "username3" => "tty0", "username4" => {}}}'
+      end
+      it { should contain_file('access_conf').with_content(/^\+ : username : tty5$/)}
+      it { should contain_file('access_conf').with_content(/^\+ : username1 : cron tty0$/)}
+      it { should contain_file('access_conf').with_content(/^\+ : username2 : cron$/)}
+      it { should contain_file('access_conf').with_content(/^\+ : username3 : tty0$/)}
+      it { should contain_file('access_conf').with_content(/^\+ : username4 : ALL$/)}
     end
 
     context 'with custom values on supported platform' do

--- a/templates/access.conf.erb
+++ b/templates/access.conf.erb
@@ -6,18 +6,18 @@
 <%
 entries = scope.lookupvar('pam::allowed_users')    
 -%>
-<% entries.each do |entry| -%>
-<%if entry.is_a? Hash -%>
-<% entry.sort.each do |key, value| -%>
-<% if value.is_a? String -%>
-+ : <%= key %> : <%= value %>
-<% elsif value.is_a? Array -%>
-+ : <%= key %> : <%= value.join(' ') %>
+<% if entries.is_a? Hash -%>
+<% entries.each do |key, value| -%>
++ : <%= key %> : <% if value.is_a? Array -%><%= value.join(' ') %><% elsif value.is_a? String -%><%= value %><% else -%>ALL<% end %>
 <% end -%>
+<% elsif entries.is_a? Array -%>
+<% entries.each do |key| -%>
++ : <%= key %> : ALL
 <% end -%>
-<% elsif entry.is_a? String -%>
-+ : <%= entry %> : ALL
-<% end -%>
+<% elsif entries.is_a? String -%>
++ : <%= entries %> : ALL
+<% else -%>
++ : root : ALL
 <% end -%>
 
 # default deny


### PR DESCRIPTION
We wanted more functionality in our access.conf. Now its able to specify origins for users and the services they should be able to access via PAM.
