### PR TITLE
Fix variable access method in template.

### DIFF
--- a/templates/login.el5.erb
+++ b/templates/login.el5.erb
@@ -13,9 +13,9 @@ session    include      system-auth
 session    optional     pam_console.so
 # pam_selinux.so open should only be followed by sessions to be executed in the user context
 session    required     pam_selinux.so open
-<% if pam_d_login_oracle_options != 'UNSET' -%>
+<% if @pam_d_login_oracle_options != 'UNSET' -%>
 # oracle options
-<% pam_d_login_oracle_options.each do |option| -%>
+<% @pam_d_login_oracle_options.each do |option| -%>
 <%= option %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
Without this patch, the following is generated on the puppet master.

Variable access via 'pam_d_login_oracle_options' is deprecated. Use
'@pam_d_login_oracle_options' instead.
