### PR TITLE
Do not include the common class as not required

### DIFF
--- a/manifests/limits.pp
+++ b/manifests/limits.pp
@@ -22,7 +22,6 @@ class pam::limits (
   include pam
 
   # ensure target exists
-  include common
   common::mkdir_p { $limits_d_dir: }
 
   file { 'limits_d':

--- a/spec/classes/limits_spec.rb
+++ b/spec/classes/limits_spec.rb
@@ -123,7 +123,6 @@ describe 'pam::limits' do
       end
 
       it { should contain_class('pam') }
-      it { should contain_class('common') }
 
       it {
         should contain_file('limits_d').with({


### PR DESCRIPTION
As far as I could tell the `common` class is not required by this module, and the use of `common::mkdir_p` does not require that class.
