### PR TITLE
Add beaker acceptance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ doc/
 coverage/
 spec/fixtures/modules/*
 Gemfile.lock
+
+# Beaker
+.vagrant/

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,8 @@ gem 'puppet', puppetversion
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 0.3.2'
 gem 'facter', '>= 1.7.0'
+
+group :development do
+  gem 'serverspec',   :require => false
+  gem 'beaker-rspec', :require => false
+end

--- a/spec/acceptance/nodesets/centos-65-x64.yml
+++ b/spec/acceptance/nodesets/centos-65-x64.yml
@@ -1,0 +1,11 @@
+HOSTS:
+  centos-65-x64:
+    roles:
+      - master
+    platform: el-6-x86_64
+    box: centos-65-x64-vbox436-nocm
+    box_url: http://puppet-vagrant-boxes.puppetlabs.com/centos-65-x64-virtualbox-nocm.box
+    hypervisor: vagrant
+CONFIG:
+  log_level: debug
+  type: foss

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,11 @@
+HOSTS:
+  centos-65-x64:
+    roles:
+      - master
+    platform: el-6-x86_64
+    box: centos-65-x64-vbox436-nocm
+    box_url: http://puppet-vagrant-boxes.puppetlabs.com/centos-65-x64-virtualbox-nocm.box
+    hypervisor: vagrant
+CONFIG:
+  log_level: debug
+  type: foss

--- a/spec/acceptance/pam_basic_spec.rb
+++ b/spec/acceptance/pam_basic_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper_acceptance'
+
+describe 'pam class:' do
+  context 'default parameters' do
+    it 'should run successfully' do
+      pp =<<-EOS
+      class { 'pam':
+        allowed_users => ['root','vagrant'],      
+      }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    os = fact('osfamily').downcase
+    os_release = fact('operatingsystemmajrelease')
+
+    it_behaves_like "pam_#{os}_#{os_release}_basic"
+    it_behaves_like "pam::accesslogin_#{os}_#{os_release}_basic"
+    it_behaves_like "pam::limits_#{os}_#{os_release}_basic"
+
+  end
+end

--- a/spec/acceptance/support/pam_accesslogin_redhat_6.rb
+++ b/spec/acceptance/support/pam_accesslogin_redhat_6.rb
@@ -1,0 +1,21 @@
+shared_examples_for 'pam::accesslogin_redhat_6_basic' do
+  describe file('/etc/security/access.conf') do
+    it { should be_file }
+    it { should be_mode 644 }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    expected_content = (<<EXPECTED).split(/\n/)
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+#
+
+# allow only the groups listed
++ : root : ALL
++ : vagrant : ALL
+
+# default deny
+- : ALL : ALL
+EXPECTED
+    it { should contain(expected_content) }
+  end
+end

--- a/spec/acceptance/support/pam_limits_redhat_6.rb
+++ b/spec/acceptance/support/pam_limits_redhat_6.rb
@@ -1,0 +1,16 @@
+shared_examples_for 'pam::limits_redhat_6_basic' do
+  describe file('/etc/security/limits.d') do
+    it { should be_directory }
+    it { should be_mode 750 }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+  end
+
+  describe file('/etc/security/limits.conf') do
+    it { should be_file }
+    it { should be_mode 640 }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    its(:content) { should match /(^#|^$)/ }
+  end
+end

--- a/spec/acceptance/support/pam_redhat_6.rb
+++ b/spec/acceptance/support/pam_redhat_6.rb
@@ -1,0 +1,95 @@
+shared_examples_for 'pam_redhat_6_basic' do
+  describe package('pam') do
+    it { should be_installed }
+  end
+
+  describe file('/etc/pam.d/login') do
+    it { should be_file }
+    it { should be_mode 644 }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    expected_content = (<<EXPECTED).split(/\n/)
+#%PAM-1.0
+auth [user_unknown=ignore success=ok ignore=ignore default=bad] pam_securetty.so
+auth       include      system-auth
+account    required     pam_nologin.so
+account    include      system-auth
+account    required     pam_access.so
+password   include      system-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+session    optional     pam_console.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open
+session    required     pam_namespace.so
+session    optional     pam_keyinit.so force revoke
+session    include      system-auth
+-session   optional     pam_ck_connector.so
+EXPECTED
+    it { should contain(expected_content) }
+  end
+
+  describe file('/etc/pam.d/sshd') do
+    it { should be_file }
+    it { should be_mode 644 }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    expected_content = (<<EXPECTED).split(/\n/)
+#%PAM-1.0
+auth       required     pam_sepermit.so
+auth       include      password-auth
+account    required     pam_access.so
+account    required     pam_nologin.so
+account    include      password-auth
+password   include      password-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open env_params
+session    optional     pam_keyinit.so force revoke
+session    include      password-auth
+EXPECTED
+    it { should contain(expected_content) }
+  end
+
+  describe file('/etc/pam.d/system-auth') do
+    it { should be_linked_to '/etc/pam.d/system-auth-ac' }
+  end
+
+  describe file('/etc/pam.d/system-auth-ac') do
+    it { should be_file }
+    it { should be_mode 644 }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    expected_content = (<<EXPECTED).split(/\n/)
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+# Auth
+auth        required      pam_env.so
+auth        sufficient    pam_fprintd.so
+auth        sufficient    pam_unix.so nullok try_first_pass
+auth        requisite     pam_succeed_if.so uid >= 500 quiet
+auth        required      pam_deny.so
+
+# Account
+account     required      pam_unix.so
+account     sufficient    pam_localuser.so
+account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     required      pam_permit.so
+
+# Password
+password    requisite     pam_cracklib.so try_first_pass retry=3 type=
+password    sufficient    pam_unix.so md5 shadow nullok try_first_pass use_authtok
+password    required      pam_deny.so
+
+# Session
+session     optional      pam_keyinit.so revoke
+session     required      pam_limits.so
+session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
+session     required      pam_unix.so
+EXPECTED
+    it { should contain(expected_content) }
+  end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,35 @@
+require 'beaker-rspec'
+
+dir = File.expand_path(File.dirname(__FILE__))
+Dir["#{dir}/acceptance/support/*.rb"].sort.each { |f| require f }
+
+hosts.each do |host|
+  # Install Puppet
+  install_puppet unless ENV['BEAKER_provision'] == 'no'
+
+  # Temporary fix till PR #67 is merged
+  osfamily = fact_on host, 'osfamily'
+  if osfamily == 'RedHat'
+    install_package host, 'redhat-lsb'
+  end
+end
+
+RSpec.configure do |c|
+  # Project root
+  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+  # Readable test descriptions
+  c.formatter = :documentation
+
+  # Configure all nodes in nodeset
+  c.before :suite do
+    # Install module and dependencies
+    puppet_module_install(:source => proj_root, :module_name => 'pam')
+
+    hosts.each do |host|
+      on host, puppet('module', 'install', 'puppetlabs-stdlib', '--version', '">= 3.2.00"'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module', 'install', 'ghoneycutt-common', '--version', '">= 1.0.2"'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module', 'install', 'ghoneycutt-nsswitch', '--version', '">= 1.1.0"'), { :acceptable_exit_codes => [0,1] }
+    end
+  end
+end


### PR DESCRIPTION
Very basic beaker tests.  Adding other operating systems and operating system releases should only require adding new node definitions under `spec/acceptance/nodesets` and appropriate files under `spec/acceptance/support`.  May be useful to begin system based tested of future changes.

The file content checking isn't great, as I had issues making multiline strings work using:

``` ruby
its(:content) { should match expected_content }
```

Some of the file contents worked, some didn't.  Likely due to characters that break the matchers used in serverspec.
