### PR TITLE
Fix order of access.conf entries when allowed_users is a Hash

### DIFF
--- a/spec/classes/accesslogin_spec.rb
+++ b/spec/classes/accesslogin_spec.rb
@@ -22,19 +22,12 @@ describe 'pam::accesslogin' do
         })
       }
 
-      it {
-        should contain_file('access_conf').with_content(
-%{# This file is being maintained by Puppet.
-# DO NOT EDIT
-#
-
-# allow only the groups listed
-+ : root : ALL
-
-# default deny
-- : ALL : ALL
-})
-      }
+      it "should contain default allowed_users" do
+        verify_contents(subject, 'access_conf', [
+          '+ : root : ALL',
+          '- : ALL : ALL',
+        ])
+      end
     end
 
     context 'with multiple users on supported platform expressed as an array' do
@@ -61,20 +54,13 @@ describe 'pam::accesslogin' do
         })
       }
 
-      it {
-        should contain_file('access_conf').with_content(
-%{# This file is being maintained by Puppet.
-# DO NOT EDIT
-#
-
-# allow only the groups listed
-+ : foo : ALL
-+ : bar : ALL
-
-# default deny
-- : ALL : ALL
-})
-      }
+      it "should contain allowed_users" do
+        verify_contents(subject, 'access_conf', [
+          '+ : foo : ALL',
+          '+ : bar : ALL',
+          '- : ALL : ALL',
+        ])
+      end
     end
 
     context 'with hash entry containing string values' do
@@ -87,8 +73,14 @@ describe 'pam::accesslogin' do
       let(:pre_condition) do
           'class {"pam": allowed_users => {"username1" => "cron", "username2" => "tty0"} }'
       end
-      it { should contain_file('access_conf').with_content(/^\+ : username1 : cron$/)}
-      it { should contain_file('access_conf').with_content(/^\+ : username2 : tty0$/)}
+
+      it "should contain allowed_users" do
+        verify_contents(subject, 'access_conf', [
+          '+ : username1 : cron',
+          '+ : username2 : tty0',
+          '- : ALL : ALL',
+        ])
+      end
     end
 
     context 'with hash entry containing array of values' do
@@ -101,7 +93,13 @@ describe 'pam::accesslogin' do
       let(:pre_condition) do
           'class {"pam": allowed_users => {"username" => ["cron", "tty0"]} }'
       end
-      it { should contain_file('access_conf').with_content(/^\+ : username : cron tty0$/)}
+
+      it "should contain allowed_users" do
+        verify_contents(subject, 'access_conf', [
+          '+ : username : cron tty0',
+          '- : ALL : ALL',
+        ])
+      end
     end
 
     context 'with hash entry containing no value should default to "ALL"' do
@@ -114,7 +112,13 @@ describe 'pam::accesslogin' do
       let(:pre_condition) do
           'class {"pam": allowed_users => {"username" => {} }}'
       end
-      it { should contain_file('access_conf').with_content(/^\+ : username : ALL$/)}
+
+      it "should contain allowed_users" do
+        verify_contents(subject, 'access_conf', [
+          '+ : username : ALL',
+          '- : ALL : ALL',
+        ])
+      end
     end
 
     context 'with hash entries containing string, array and empty hash' do
@@ -127,11 +131,17 @@ describe 'pam::accesslogin' do
       let(:pre_condition) do
           'class {"pam": allowed_users => {"username" => "tty5", "username1" => ["cron", "tty0"], "username2" => "cron", "username3" => "tty0", "username4" => {}}}'
       end
-      it { should contain_file('access_conf').with_content(/^\+ : username : tty5$/)}
-      it { should contain_file('access_conf').with_content(/^\+ : username1 : cron tty0$/)}
-      it { should contain_file('access_conf').with_content(/^\+ : username2 : cron$/)}
-      it { should contain_file('access_conf').with_content(/^\+ : username3 : tty0$/)}
-      it { should contain_file('access_conf').with_content(/^\+ : username4 : ALL$/)}
+
+      it "should contain allowed_users" do
+        verify_contents(subject, 'access_conf', [
+          '+ : username : tty5',
+          '+ : username1 : cron tty0',
+          '+ : username2 : cron',
+          '+ : username3 : tty0',
+          '+ : username4 : ALL',
+          '- : ALL : ALL',
+        ])
+      end
     end
 
     context 'with custom values on supported platform' do

--- a/templates/access.conf.erb
+++ b/templates/access.conf.erb
@@ -7,7 +7,8 @@
 entries = scope.lookupvar('pam::allowed_users')
 -%>
 <% if entries.is_a? Hash -%>
-<% entries.each do |key, value| -%>
+<% entries.keys.sort.each do |key| -%>
+<% value = entries[key] -%>
 + : <%= key %> : <% if value.is_a? Array -%><%= value.join(' ') %><% elsif value.is_a? String -%><%= value %><% else -%>ALL<% end %>
 <% end -%>
 <% elsif entries.is_a? Array -%>


### PR DESCRIPTION
In Ruby 1.8.7 the order of a Hash is "random" [1].  One way to ensure consistent order of elements when iterating over a Hash is to sort by the keys then reference the value using `Hash[key]`.  Example of RSpec test output before changing `templates/access.conf.erb`.

```
Failures:

  1) pam::accesslogin access.conf with hash entry containing string values should contain allowed_users
     Failure/Error: verify_contents(subject, 'access_conf', [
       expected: ["+ : username1 : cron", "+ : username2 : tty0", "- : ALL : ALL"]
            got: ["+ : username2 : tty0", "+ : username1 : cron", "- : ALL : ALL"] (using ==)
     # ./spec/classes/accesslogin_spec.rb:92

  2) pam::accesslogin access.conf with hash entries containing string, array and empty hash should contain allowed_users
     Failure/Error: verify_contents(subject, 'access_conf', [
       expected: ["+ : username : tty5", "+ : username1 : cron tty0", "+ : username2 : cron", "+ : username3 : tty0", "+ : username4 : ALL", "- : ALL : ALL"]
            got: ["+ : username : tty5", "+ : username3 : tty0", "+ : username1 : cron tty0", "+ : username2 : cron", "+ : username4 : ALL", "- : ALL : ALL"] (using ==)
     # ./spec/classes/accesslogin_spec.rb:150
```

I observed this issue in production when using a Hash defined in Hiera. Puppet kept changing the order of  the "allow" entries in access.conf.

[1] : http://www.ruby-doc.org/core-1.8.7/Hash.html - "The order in which you traverse a hash by either key or value may seem arbitrary, and will generally not be in the insertion order."