### PR TITLE
Add the 'purge_limits_d_dir' parameter to pam::limits

### DIFF
--- a/manifests/limits.pp
+++ b/manifests/limits.pp
@@ -3,10 +3,11 @@
 # Manage PAM limits.conf
 #
 class pam::limits (
-  $config_file       = '/etc/security/limits.conf',
-  $config_file_mode  = '0640',
-  $limits_d_dir      = '/etc/security/limits.d',
-  $limits_d_dir_mode = '0750',
+  $config_file        = '/etc/security/limits.conf',
+  $config_file_mode   = '0640',
+  $limits_d_dir       = '/etc/security/limits.d',
+  $limits_d_dir_mode  = '0750',
+  $purge_limits_d_dir = false,
 ) {
 
   # validate params
@@ -19,6 +20,8 @@ class pam::limits (
   validate_re($limits_d_dir_mode, '^[0-7]{4}$',
     "pam::limits::limits_d_dir_mode is <${limits_d_dir_mode}> and must be a valid four digit mode in octal notation.")
 
+  validate_bool($purge_limits_d_dir)
+
   include pam
 
   # ensure target exists
@@ -30,6 +33,8 @@ class pam::limits (
     owner   => 'root',
     group   => 'root',
     mode    => $limits_d_dir_mode,
+    purge   => $purge_limits_d_dir,
+    recurse => $purge_limits_d_dir,
     require => [ Package[$pam::my_package_name],
                 Common::Mkdir_p[$limits_d_dir],
                 ],

--- a/spec/classes/limits_spec.rb
+++ b/spec/classes/limits_spec.rb
@@ -104,6 +104,8 @@ describe 'pam::limits' do
           'owner'   => 'root',
           'group'   => 'root',
           'mode'    => '0750',
+          'purge'   => 'false',
+          'recurse' => 'false',
           'require' => [ 'Package[pam]', 'Package[util-linux]', 'Common::Mkdir_p[/etc/security/limits.d]' ],
         })
       }
@@ -135,7 +137,32 @@ describe 'pam::limits' do
           'owner'   => 'root',
           'group'   => 'root',
           'mode'    => '0700',
+          'purge'   => 'false',
+          'recurse' => 'false',
           'require' => [ 'Package[pam]', 'Package[util-linux]', 'Common::Mkdir_p[/custom/security/limits.d]' ],
+        })
+      }
+    end
+
+    context 'when purge_limits_d_dir => true' do
+      let(:params) { { :purge_limits_d_dir => true } }
+      let(:facts) do
+        {
+          :osfamily          => 'RedHat',
+          :lsbmajdistrelease => '5',
+        }
+      end
+
+      it {
+        should contain_file('limits_d').with({
+          'ensure'  => 'directory',
+          'path'    => '/etc/security/limits.d',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0750',
+          'purge'   => 'true',
+          'recurse' => 'true',
+          'require' => [ 'Package[pam]', 'Package[util-linux]', 'Common::Mkdir_p[/etc/security/limits.d]' ],
         })
       }
     end
@@ -169,6 +196,22 @@ describe 'pam::limits' do
         expect {
           should contain_class('pam::limits')
         }.to raise_error(Puppet::Error,/pam::limits::limits_d_dir_mode is <777> and must be a valid four digit mode in octal notation./)
+      end
+    end
+
+    context 'when purge_limits_d_dir is invalid' do
+      let(:params) { { :purge_limits_d_dir => 'foo' } }
+      let(:facts) do
+        {
+          :osfamily          => 'RedHat',
+          :lsbmajdistrelease => '5',
+        }
+      end
+
+      it 'should fail' do
+        expect {
+          should contain_class('pam::limits')
+        }.to raise_error(Puppet::Error,/not a boolean/)
       end
     end
   end


### PR DESCRIPTION
Default is false for backwards compatibility.  Should probably be changed to true when a jump to version 3 is needed.