### PR TITLE
EL 6 - Adding support for password-auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,41 @@ Content template of $system_auth_ac_file. If undef, parameter is set based on th
 
 - *Default*: undef, default is set based on OS version
 
+password_auth_file
+----------------
+Path to password-auth. Used on RedHat.
+
+- *Default*: '/etc/pam.d/password-auth'
+
+password_auth_ac_file
+-------------------
+Path to password-auth-ac. Used on RedHat.
+
+- *Default*: '/etc/pam.d/password-auth-ac'
+
+pam_password_auth_lines
+-------------------------
+Content template of $password_auth_ac_file. If undef, parameter is set based on the OS version.
+
+- *Default*: undef, default is set based on OS version
+
+pam_password_account_lines
+----------------------------
+Content template of $password_auth_ac_file. If undef, parameter is set based on the OS version.
+
+- *Default*: undef, default is set based on OS version
+
+pam_password_pswd_lines 
+-----------------------------
+Content template of $password_auth_ac_file. If undef, parameter is set based on the OS version.
+
+- *Default*: undef, default is set based on OS version
+
+pam_password_session_lines 
+----------------------------
+Content template of $password_auth_ac_file. If undef, parameter is set based on the OS version.
+
+- *Default*: undef, default is set based on OS version
 ===
 
 # define pam::accesslogin

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -822,7 +822,6 @@ class pam (
     create_resources('pam::limits::fragment',$limits_fragments)
   }
 
-  validate_absolute_path($password_auth_file)
   validate_absolute_path($password_auth_ac_file)
 
   case $::osfamily {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -264,6 +264,85 @@ class pam (
                                                     'session     required      pam_unix.so']
           }
         }
+        '7': {
+          $default_pam_d_login_template = 'pam/login.el7.erb'
+          $default_pam_d_sshd_template  = 'pam/sshd.el7.erb'
+          $default_package_name         = 'pam'
+
+          if $ensure_vas == 'present' {
+            case $vas_major_version {
+              '4': {
+                $default_pam_auth_lines = [
+                  'auth        required      pam_env.so',
+                  'auth        sufficient    pam_vas3.so show_lockout_msg get_nonvas_pass',
+                  'auth        requisite     pam_vas3.so echo_return',
+                  'auth        sufficient    pam_unix.so nullok try_first_pass use_first_pass',
+                  'auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success',
+                  'auth        required      pam_deny.so'
+                ]
+              }
+              default: {
+                fail("Pam is only supported with vas_major_version 4 on EL7. Your vas_major_version is <${vas_major_version}>.")
+              }
+            }
+
+            $default_pam_account_lines = [
+              'account     sufficient    pam_vas3.so',
+              'account     requisite     pam_vas3.so echo_return',
+              'account     required      pam_unix.so',
+              'account     sufficient    pam_localuser.so',
+              'account     sufficient    pam_succeed_if.so uid < 1000 quiet',
+              'account     required      pam_permit.so'
+            ]
+
+            $default_pam_password_lines = [
+              'password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=',
+              'password    sufficient    pam_vas3.so',
+              'password    requisite     pam_vas3.so echo_return',
+              'password    sufficient    pam_unix.so md5 shadow nullok try_first_pass use_authtok',
+              'password    required      pam_deny.so'
+            ]
+
+            $default_pam_session_lines = [
+              'session     optional      pam_keyinit.so revoke',
+              'session     required      pam_limits.so',
+              '-session    optional      pam_systemd.so',
+              'session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid',
+              'session     required      pam_vas3.so show_lockout_msg',
+              'session     requisite     pam_vas3.so echo_return',
+              'session     required      pam_unix.so'
+            ]
+          } else {
+            $default_pam_auth_lines = [
+              'auth        required      pam_env.so',
+              'auth        sufficient    pam_fprintd.so',
+              'auth        sufficient    pam_unix.so nullok try_first_pass',
+              'auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success',
+              'auth        required      pam_deny.so'
+            ]
+
+            $default_pam_account_lines = [
+              'account     required      pam_unix.so',
+              'account     sufficient    pam_localuser.so',
+              'account     sufficient    pam_succeed_if.so uid < 1000 quiet',
+              'account     required      pam_permit.so'
+            ]
+
+            $default_pam_password_lines = [
+              'password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=',
+              'password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok',
+              'password    required      pam_deny.so'
+            ]
+
+            $default_pam_session_lines = [
+              'session     optional      pam_keyinit.so revoke',
+              'session     required      pam_limits.so',
+              '-session    optional      pam_systemd.so',
+              'session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid',
+              'session     required      pam_unix.so'
+            ]
+          }
+        }
         default: {
           fail("Pam is only supported on EL 5, 6 and 7. Your operatingsystemmajrelease is identified as <${::operatingsystemmajrelease}>.")
         }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,12 @@ class pam (
   $common_session_noninteractive_file  = '/etc/pam.d/common-session-noninteractive',
   $system_auth_file                    = '/etc/pam.d/system-auth',
   $system_auth_ac_file                 = '/etc/pam.d/system-auth-ac',
+  $password_auth_file                  = '/etc/pam.d/password-auth',
+  $password_auth_ac_file               = '/etc/pam.d/password-auth-ac',
+  $pam_password_auth_lines             = undef,
+  $pam_password_account_lines          = undef,
+  $pam_password_pswd_lines             = undef,
+  $pam_password_session_lines          = undef,
   $system_auth_ac_auth_lines           = undef,
   $system_auth_ac_account_lines        = undef,
   $system_auth_ac_password_lines       = undef,
@@ -143,162 +149,119 @@ class pam (
           if $ensure_vas == 'present' {
             case $vas_major_version {
               '3': {
-                $default_pam_auth_lines = [
-                  'auth        required      pam_env.so',
-                  'auth        sufficient    pam_vas3.so show_lockout_msg get_nonvas_pass store_creds',
-                  'auth        requisite     pam_vas3.so echo_return',
-                  'auth        sufficient    pam_unix.so nullok try_first_pass use_first_pass',
-                  'auth        requisite     pam_succeed_if.so uid >= 500 quiet',
-                  'auth        required      pam_deny.so'
-                ]
+                $default_pam_auth_lines = [ 'auth        required      pam_env.so',
+                                            'auth        sufficient    pam_vas3.so show_lockout_msg get_nonvas_pass store_creds',
+                                            'auth        requisite     pam_vas3.so echo_return',
+                                            'auth        sufficient    pam_unix.so nullok try_first_pass use_first_pass',
+                                            'auth        requisite     pam_succeed_if.so uid >= 500 quiet',
+                                            'auth        required      pam_deny.so']
+
+                $default_pam_password_auth_lines = [ 'auth    required        pam_env.so',
+                                                      'auth    sufficient      pam_vas3.so create_homedir get_nonvas_pass',
+                                                      'auth    requisite       pam_vas3.so echo_return',
+                                                      'auth    sufficient      pam_unix.so nullok try_first_pass use_first_pass',
+                                                      'auth    requisite       pam_succeed_if.so uid >= 500 quiet',
+                                                      'auth    required        pam_deny.so']
+
               }
               '4': {
-                $default_pam_auth_lines = [
-                  'auth        required      pam_env.so',
-                  'auth        sufficient    pam_vas3.so show_lockout_msg get_nonvas_pass',
-                  'auth        requisite     pam_vas3.so echo_return',
-                  'auth        sufficient    pam_unix.so nullok try_first_pass use_first_pass',
-                  'auth        requisite     pam_succeed_if.so uid >= 500 quiet',
-                  'auth        required      pam_deny.so'
-                ]
+                $default_pam_auth_lines = [ 'auth        required      pam_env.so',
+                                            'auth        sufficient    pam_vas3.so show_lockout_msg get_nonvas_pass',
+                                            'auth        requisite     pam_vas3.so echo_return',
+                                            'auth        sufficient    pam_unix.so nullok try_first_pass use_first_pass',
+                                            'auth        requisite     pam_succeed_if.so uid >= 500 quiet',
+                                            'auth        required      pam_deny.so']
+
+                $default_pam_password_auth_lines = [ 'auth    required        pam_env.so',
+                                                      'auth    sufficient      pam_vas3.so create_homedir get_nonvas_pass',
+                                                      'auth    requisite       pam_vas3.so echo_return',
+                                                      'auth    sufficient      pam_unix.so nullok try_first_pass use_first_pass',
+                                                      'auth    requisite       pam_succeed_if.so uid >= 500 quiet',
+                                                      'auth    required        pam_deny.so']
               }
               default: {
                 fail("Pam is only supported with vas_major_version 3 or 4. Your vas_major_version is <${vas_major_version}>.")
               }
             }
 
-            $default_pam_account_lines = [
-              'account     sufficient    pam_vas3.so',
-              'account     requisite     pam_vas3.so echo_return',
-              'account     required      pam_unix.so',
-              'account     sufficient    pam_localuser.so',
-              'account     sufficient    pam_succeed_if.so uid < 500 quiet',
-              'account     required      pam_permit.so'
-            ]
+            $default_pam_account_lines = [ 'account     sufficient    pam_vas3.so',
+                                            'account     requisite     pam_vas3.so echo_return',
+                                            'account     required      pam_unix.so',
+                                            'account     sufficient    pam_localuser.so',
+                                            'account     sufficient    pam_succeed_if.so uid < 500 quiet',
+                                            'account     required      pam_permit.so']
 
-            $default_pam_password_lines = [
-              'password    sufficient    pam_vas3.so',
-              'password    requisite     pam_vas3.so echo_return',
-              'password    requisite     pam_cracklib.so try_first_pass retry=3 type=',
-              'password    sufficient    pam_unix.so md5 shadow nullok try_first_pass use_authtok',
-              'password    required      pam_deny.so'
-            ]
+            $default_pam_password_lines = [ 'password    sufficient    pam_vas3.so',
+                                            'password    requisite     pam_vas3.so echo_return',
+                                            'password    requisite     pam_cracklib.so try_first_pass retry=3 type=',
+                                            'password    sufficient    pam_unix.so md5 shadow nullok try_first_pass use_authtok',
+                                            'password    required      pam_deny.so']
 
-            $default_pam_session_lines = [
-              'session     optional      pam_keyinit.so revoke',
-              'session     required      pam_limits.so',
-              'session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid',
-              'session     required      pam_vas3.so show_lockout_msg',
-              'session     requisite     pam_vas3.so echo_return',
-              'session     required      pam_unix.so'
-            ]
+            $default_pam_session_lines = [ 'session     optional      pam_keyinit.so revoke',
+                                            'session     required      pam_limits.so',
+                                            'session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid',
+                                            'session     required      pam_vas3.so show_lockout_msg',
+                                            'session     requisite     pam_vas3.so echo_return',
+                                            'session     required      pam_unix.so']
+
+            $default_pam_password_account_lines = [ 'account sufficient      pam_vas3.so',
+                                                    'account requisite       pam_vas3.so echo_return',
+                                                    'account required        pam_unix.so',
+                                                    'account sufficient      pam_localuser.so',
+                                                    'account sufficient      pam_succeed_if.so uid < 500 quiet',
+                                                    'account required        pam_permit.so']
+
+            $default_pam_password_pswd_lines = [ 'password        sufficient      pam_vas3.so',
+                                                  'password        requisite       pam_vas3.so echo_return',
+                                                  'password        requisite       pam_cracklib.so try_first_pass retry=3 type=',
+                                                  'password        sufficient      pam_unix.so md5 shadow nullok try_first_pass use_authtok',
+                                                  'password        required        pam_deny.so']
+
+            $default_pam_password_session_lines = [ 'session optional        pam_keyinit.so revoke',
+                                                    'session required        pam_limits.so',
+                                                    'session [success=1 default=ignore]      pam_succeed_if.so service in crond quiet use_uid',
+                                                    'session required        pam_vas3.so create_homedir',
+                                                    'session requisite       pam_vas3.so echo_return',
+                                                    'session required        pam_unix.so']
           } else {
-            $default_pam_auth_lines = [
-              'auth        required      pam_env.so',
-              'auth        sufficient    pam_fprintd.so',
-              'auth        sufficient    pam_unix.so nullok try_first_pass',
-              'auth        requisite     pam_succeed_if.so uid >= 500 quiet',
-              'auth        required      pam_deny.so'
-            ]
+            $default_pam_auth_lines = [ 'auth        required      pam_env.so',
+                                        'auth        sufficient    pam_fprintd.so',
+                                        'auth        sufficient    pam_unix.so nullok try_first_pass',
+                                        'auth        requisite     pam_succeed_if.so uid >= 500 quiet',
+                                        'auth        required      pam_deny.so']
 
-            $default_pam_account_lines = [
-              'account     required      pam_unix.so',
-              'account     sufficient    pam_localuser.so',
-              'account     sufficient    pam_succeed_if.so uid < 500 quiet',
-              'account     required      pam_permit.so'
-            ]
+            $default_pam_password_auth_lines = [ 'auth        required      pam_env.so',
+                                                  'auth        sufficient    pam_unix.so nullok try_first_pass',
+                                                  'auth        requisite     pam_succeed_if.so uid >= 500 quiet',
+                                                  'auth        required      pam_deny.so']
 
-            $default_pam_password_lines = [
-              'password    requisite     pam_cracklib.so try_first_pass retry=3 type=',
-              'password    sufficient    pam_unix.so md5 shadow nullok try_first_pass use_authtok',
-              'password    required      pam_deny.so'
-            ]
+            $default_pam_account_lines = [ 'account     required      pam_unix.so',
+                                            'account     sufficient    pam_localuser.so',
+                                            'account     sufficient    pam_succeed_if.so uid < 500 quiet',
+                                            'account     required      pam_permit.so']
 
-            $default_pam_session_lines = [
-              'session     optional      pam_keyinit.so revoke',
-              'session     required      pam_limits.so',
-              'session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid',
-              'session     required      pam_unix.so'
-            ]
-          }
-        }
-        '7': {
-          $default_pam_d_login_template = 'pam/login.el7.erb'
-          $default_pam_d_sshd_template  = 'pam/sshd.el7.erb'
-          $default_package_name         = 'pam'
+            $default_pam_password_lines = [ 'password    requisite     pam_cracklib.so try_first_pass retry=3 type=',
+                                            'password    sufficient    pam_unix.so md5 shadow nullok try_first_pass use_authtok',
+                                            'password    required      pam_deny.so']
 
-          if $ensure_vas == 'present' {
-            case $vas_major_version {
-              '4': {
-                $default_pam_auth_lines = [
-                  'auth        required      pam_env.so',
-                  'auth        sufficient    pam_vas3.so show_lockout_msg get_nonvas_pass',
-                  'auth        requisite     pam_vas3.so echo_return',
-                  'auth        sufficient    pam_unix.so nullok try_first_pass use_first_pass',
-                  'auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success',
-                  'auth        required      pam_deny.so'
-                ]
-              }
-              default: {
-                fail("Pam is only supported with vas_major_version 4 on EL7. Your vas_major_version is <${vas_major_version}>.")
-              }
-            }
+            $default_pam_session_lines = [ 'session     optional      pam_keyinit.so revoke',
+                                            'session     required      pam_limits.so',
+                                            'session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid',
+                                            'session     required      pam_unix.so']
 
-            $default_pam_account_lines = [
-              'account     sufficient    pam_vas3.so',
-              'account     requisite     pam_vas3.so echo_return',
-              'account     required      pam_unix.so',
-              'account     sufficient    pam_localuser.so',
-              'account     sufficient    pam_succeed_if.so uid < 1000 quiet',
-              'account     required      pam_permit.so'
-            ]
+            $default_pam_password_account_lines = [ 'account     required      pam_unix.so',
+                                                    'account     sufficient    pam_localuser.so',
+                                                    'account     sufficient    pam_succeed_if.so uid < 500 quiet',
+                                                    'account     required      pam_permit.so']
 
-            $default_pam_password_lines = [
-              'password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=',
-              'password    sufficient    pam_vas3.so',
-              'password    requisite     pam_vas3.so echo_return',
-              'password    sufficient    pam_unix.so md5 shadow nullok try_first_pass use_authtok',
-              'password    required      pam_deny.so'
-            ]
+            $default_pam_password_pswd_lines = [ 'password    requisite     pam_cracklib.so try_first_pass retry=3 type=',
+                                                  'password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok',
+                                                  'password    required      pam_deny.so']
 
-            $default_pam_session_lines = [
-              'session     optional      pam_keyinit.so revoke',
-              'session     required      pam_limits.so',
-              '-session    optional      pam_systemd.so',
-              'session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid',
-              'session     required      pam_vas3.so show_lockout_msg',
-              'session     requisite     pam_vas3.so echo_return',
-              'session     required      pam_unix.so'
-            ]
-          } else {
-            $default_pam_auth_lines = [
-              'auth        required      pam_env.so',
-              'auth        sufficient    pam_fprintd.so',
-              'auth        sufficient    pam_unix.so nullok try_first_pass',
-              'auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success',
-              'auth        required      pam_deny.so'
-            ]
-
-            $default_pam_account_lines = [
-              'account     required      pam_unix.so',
-              'account     sufficient    pam_localuser.so',
-              'account     sufficient    pam_succeed_if.so uid < 1000 quiet',
-              'account     required      pam_permit.so'
-            ]
-
-            $default_pam_password_lines = [
-              'password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=',
-              'password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok',
-              'password    required      pam_deny.so'
-            ]
-
-            $default_pam_session_lines = [
-              'session     optional      pam_keyinit.so revoke',
-              'session     required      pam_limits.so',
-              '-session    optional      pam_systemd.so',
-              'session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid',
-              'session     required      pam_unix.so'
-            ]
+            $default_pam_password_session_lines = [ 'session     optional      pam_keyinit.so revoke',
+                                                    'session     required      pam_limits.so',
+                                                    'session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid',
+                                                    'session     required      pam_unix.so']
           }
         }
         default: {
@@ -827,6 +790,30 @@ class pam (
     $my_pam_session_lines = $pam_session_lines
   }
 
+  if $pam_password_auth_lines == undef {
+      $my_pam_password_auth_lines = $default_pam_password_auth_lines
+  } else {
+    $my_pam_password_auth_lines = $pam_password_auth_lines
+  }
+
+  if $pam_password_account_lines == undef {
+      $my_pam_password_account_lines = $default_pam_password_account_lines
+  } else {
+    $my_pam_password_account_lines = $pam_password_account_lines
+  }
+
+  if $pam_password_pswd_lines == undef {
+      $my_pam_password_pswd_lines = $default_pam_password_pswd_lines
+  } else {
+    $my_pam_password_pswd_lines = $pam_password_pswd_lines
+  }
+
+  if $pam_password_session_lines == undef {
+      $my_pam_password_session_lines = $default_pam_password_session_lines
+  } else {
+    $my_pam_password_session_lines = $pam_password_session_lines
+  }
+
   if $services != undef {
     create_resources('pam::service',$services)
   }
@@ -865,26 +852,72 @@ class pam (
 
       case $::osfamily {
         'RedHat': {
+          case $::lsbmajdistrelease {
+            '5': {
 
-          file { 'pam_system_auth_ac':
-            ensure  => file,
-            path    => $system_auth_ac_file,
-            content => template('pam/system-auth-ac.erb'),
-            owner   => 'root',
-            group   => 'root',
-            mode    => '0644',
-            require => Package[$my_package_name],
+              file { 'pam_system_auth_ac':
+                ensure  => file,
+                path    => $system_auth_ac_file,
+                content => template('pam/system-auth-ac.erb'),
+                owner   => 'root',
+                group   => 'root',
+                mode    => '0644',
+                require => Package[$my_package_name],
+              }
+
+              file { 'pam_system_auth':
+                ensure  => symlink,
+                path    => $system_auth_file,
+                target  => $system_auth_ac_file,
+                owner   => 'root',
+                group   => 'root',
+                require => Package[$my_package_name],
+              }
+            }
+            '6': {
+
+              file { 'pam_system_auth_ac':
+                ensure  => file,
+                path    => $system_auth_ac_file,
+                content => template('pam/system-auth-ac.erb'),
+                owner   => 'root',
+                group   => 'root',
+                mode    => '0644',
+                require => Package[$my_package_name],
+              }
+
+              file { 'pam_system_auth':
+                ensure  => symlink,
+                path    => $system_auth_file,
+                target  => $system_auth_ac_file,
+                owner   => 'root',
+                group   => 'root',
+                require => Package[$my_package_name],
+              }
+
+              file { 'pam_password_auth_ac':
+                ensure  => file,
+                path    => $password_auth_ac_file,
+                content => template('pam/password-auth-ac.erb'),
+                owner   => 'root',
+                group   => 'root',
+                mode    => '0644',
+                require => Package[$my_package_name],
+              }
+
+              file { 'pam_password_auth':
+                ensure  => symlink,
+                path    => $password_auth_file,
+                target  => $password_auth_ac_file,
+                owner   => 'root',
+                group   => 'root',
+                require => Package[$my_package_name],
+              }
+            }
+            default : {
+              fail("Pam is only supported on RedHat 5 and 6. Your lsbmajdistrelease is identified as <${::lsbmajdistrelease}>.")
+            }
           }
-
-          file { 'pam_system_auth':
-            ensure  => symlink,
-            path    => $system_auth_file,
-            target  => $system_auth_ac_file,
-            owner   => 'root',
-            group   => 'root',
-            require => Package[$my_package_name],
-          }
-
         }
         'Debian' : {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -822,6 +822,9 @@ class pam (
     create_resources('pam::limits::fragment',$limits_fragments)
   }
 
+  validate_absolute_path($password_auth_file)
+  validate_absolute_path($password_auth_ac_file)
+
   case $::osfamily {
     'RedHat', 'Suse', 'Debian': {
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -605,7 +605,7 @@ session    include      password-auth
           'mode'    => '0644',
         })
       }
-	  it { should contain_file('pam_password_auth_ac').with_content("# This file is being maintained by Puppet.
+      it { should contain_file('pam_password_auth_ac').with_content("# This file is being maintained by Puppet.
 # DO NOT EDIT
 # Auth
 auth        required      pam_env.so
@@ -631,7 +631,7 @@ session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet 
 session     required      pam_unix.so
 ")
       }
-	  it {
+      it {
         should contain_file('pam_password_auth').with({
           'ensure' => 'symlink',
           'path'   => '/etc/pam.d/password-auth',
@@ -641,238 +641,20 @@ session     required      pam_unix.so
       }
     end
 
-    context 'with login_pam_access => sufficient on osfamily RedHat with operatingsystemmajrelease 6' do
-      let :facts do
-        {
-          :osfamily                  => 'RedHat',
-          :operatingsystemmajrelease => '6',
-        }
-      end
-
-      let(:params) {{ :login_pam_access => 'sufficient' }}
-
-      it { should contain_file('pam_d_login').with_content("#%PAM-1.0
-auth [user_unknown=ignore success=ok ignore=ignore default=bad] pam_securetty.so
-auth       include      system-auth
-account    required     pam_nologin.so
-account    include      system-auth
-account    sufficient     pam_access.so
-password   include      system-auth
-# pam_selinux.so close should be the first session rule
-session    required     pam_selinux.so close
-session    required     pam_loginuid.so
-session    optional     pam_console.so
-# pam_selinux.so open should only be followed by sessions to be executed in the user context
-session    required     pam_selinux.so open
-session    required     pam_namespace.so
-session    optional     pam_keyinit.so force revoke
-session    include      system-auth
--session   optional     pam_ck_connector.so
-")
+  context 'pam_password_auth_ac set to a non absolute path' do
+    let(:params) { { :pam_password_auth_ac => 'invalid/path' } }
+    let(:facts) do
+      { :osfamily          => 'RedHat',
+        :lsbmajdistrelease => '6',
       }
     end
 
-    context 'with sshd_pam_access => sufficient on osfamily RedHat with operatingsystemmajrelease 6' do
-      let :facts do
-        {
-          :osfamily                  => 'RedHat',
-          :operatingsystemmajrelease => '6',
-        }
-      end
-
-      let(:params) {{ :sshd_pam_access => 'sufficient' }}
-
-      it { should contain_file('pam_d_sshd').with_content("#%PAM-1.0
-auth       required     pam_sepermit.so
-auth       include      password-auth
-account    sufficient     pam_access.so
-account    required     pam_nologin.so
-account    include      password-auth
-password   include      password-auth
-# pam_selinux.so close should be the first session rule
-session    required     pam_selinux.so close
-session    required     pam_loginuid.so
-# pam_selinux.so open should only be followed by sessions to be executed in the user context
-session    required     pam_selinux.so open env_params
-session    optional     pam_keyinit.so force revoke
-session    include      password-auth
-")
-      }
+    it 'should fail' do
+      expect {
+        should contain_class('pam')
+      }.to raise_error(Puppet::Error)
     end
-
-    context 'with login_pam_access => absent on osfamily RedHat with operatingsystemmajrelease 6' do
-      let :facts do
-        {
-          :osfamily                  => 'RedHat',
-          :operatingsystemmajrelease => '6',
-        }
-      end
-
-      let(:params) {{ :login_pam_access => 'absent' }}
-
-      it { should contain_file('pam_d_login').with_content("#%PAM-1.0
-auth [user_unknown=ignore success=ok ignore=ignore default=bad] pam_securetty.so
-auth       include      system-auth
-account    required     pam_nologin.so
-account    include      system-auth
-password   include      system-auth
-# pam_selinux.so close should be the first session rule
-session    required     pam_selinux.so close
-session    required     pam_loginuid.so
-session    optional     pam_console.so
-# pam_selinux.so open should only be followed by sessions to be executed in the user context
-session    required     pam_selinux.so open
-session    required     pam_namespace.so
-session    optional     pam_keyinit.so force revoke
-session    include      system-auth
--session   optional     pam_ck_connector.so
-")
-      }
-    end
-
-    context 'with sshd_pam_access => absent on osfamily RedHat with operatingsystemmajrelease 6' do
-      let :facts do
-        {
-          :osfamily                  => 'RedHat',
-          :operatingsystemmajrelease => '6',
-        }
-      end
-
-      let(:params) {{ :sshd_pam_access => 'absent' }}
-
-      it { should contain_file('pam_d_sshd').with_content("#%PAM-1.0
-auth       required     pam_sepermit.so
-auth       include      password-auth
-account    required     pam_nologin.so
-account    include      password-auth
-password   include      password-auth
-# pam_selinux.so close should be the first session rule
-session    required     pam_selinux.so close
-session    required     pam_loginuid.so
-# pam_selinux.so open should only be followed by sessions to be executed in the user context
-session    required     pam_selinux.so open env_params
-session    optional     pam_keyinit.so force revoke
-session    include      password-auth
-")
-      }
-    end
-
-    context 'with default params on osfamily RedHat with operatingsystemmajrelease 7' do
-      let :facts do
-        {
-          :osfamily                  => 'RedHat',
-          :operatingsystemmajrelease => '7',
-        }
-      end
-
-      it {
-        should contain_file('pam_system_auth_ac').with({
-          'ensure'  => 'file',
-          'path'    => '/etc/pam.d/system-auth-ac',
-          'owner'   => 'root',
-          'group'   => 'root',
-          'mode'    => '0644',
-        })
-      }
-      it { should contain_file('pam_system_auth_ac').with_content("# This file is being maintained by Puppet.
-# DO NOT EDIT
-# Auth
-auth        required      pam_env.so
-auth        sufficient    pam_fprintd.so
-auth        sufficient    pam_unix.so nullok try_first_pass
-auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success
-auth        required      pam_deny.so
-
-# Account
-account     required      pam_unix.so
-account     sufficient    pam_localuser.so
-account     sufficient    pam_succeed_if.so uid < 1000 quiet
-account     required      pam_permit.so
-
-# Password
-password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
-password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok
-password    required      pam_deny.so
-
-# Session
-session     optional      pam_keyinit.so revoke
-session     required      pam_limits.so
--session    optional      pam_systemd.so
-session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
-session     required      pam_unix.so
-")
-      }
-
-      it {
-        should contain_file('pam_system_auth').with({
-          'ensure' => 'symlink',
-          'path'   => '/etc/pam.d/system-auth',
-          'owner'  => 'root',
-          'group'  => 'root',
-        })
-      }
-
-      it {
-        should contain_file('pam_d_login').with({
-          'ensure' => 'file',
-          'path'   => '/etc/pam.d/login',
-          'owner'  => 'root',
-          'group'  => 'root',
-          'mode'   => '0644',
-        })
-      }
-
-      it { should contain_file('pam_d_login').with_content("#%PAM-1.0
-auth [user_unknown=ignore success=ok ignore=ignore default=bad] pam_securetty.so
-auth       substack     system-auth
-auth       include      postlogin
-account    required     pam_nologin.so
-account    include      system-auth
-password   include      system-auth
-# pam_selinux.so close should be the first session rule
-session    required     pam_selinux.so close
-session    required     pam_loginuid.so
-session    optional     pam_console.so
-# pam_selinux.so open should only be followed by sessions to be executed in the user context
-session    required     pam_selinux.so open
-session    required     pam_namespace.so
-session    optional     pam_keyinit.so force revoke
-session    include      system-auth
-session    include      postlogin
--session   optional     pam_ck_connector.so
-")
-      }
-
-      it {
-        should contain_file('pam_d_sshd').with({
-          'ensure' => 'file',
-          'path'   => '/etc/pam.d/sshd',
-          'owner'  => 'root',
-          'group'  => 'root',
-          'mode'   => '0644',
-        })
-      }
-
-      it { should contain_file('pam_d_sshd').with_content("#%PAM-1.0
-auth       required     pam_sepermit.so
-auth       substack     password-auth
-auth       include      postlogin
-account    required     pam_nologin.so
-account    include      password-auth
-password   include      password-auth
-# pam_selinux.so close should be the first session rule
-session    required     pam_selinux.so close
-session    required     pam_loginuid.so
-# pam_selinux.so open should only be followed by sessions to be executed in the user context
-session    required     pam_selinux.so open env_params
-session    optional     pam_keyinit.so force revoke
-session    include      password-auth
-session    include      postlogin
-")
-      }
-
-      it { should_not contain_file('pam_system_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so/) }
-    end
+  end
 
     context 'with default params on Ubuntu 12.04 LTS' do
       let :facts do
@@ -1121,7 +903,7 @@ account  required  pam_unix2.so
           'owner'   => 'root',
           'group'   => 'root',
           'mode'    => '0644',
-         })
+        })
       }
 
       it { should contain_file('pam_common_password').with_content("# This file is being maintained by Puppet.
@@ -1138,7 +920,7 @@ password  required  pam_unix2.so nullok use_authtok
           'owner'   => 'root',
           'group'   => 'root',
           'mode'    => '0644',
-         })
+        })
       }
 
       it { should contain_file('pam_common_session').with_content("# This file is being maintained by Puppet.

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -530,6 +530,7 @@ session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet 
 session     required      pam_unix.so
 ")
       }
+
       it {
         should contain_file('pam_system_auth').with({
           'ensure' => 'symlink',
@@ -538,6 +539,7 @@ session     required      pam_unix.so
           'group'  => 'root',
         })
       }
+
       it {
         should contain_file('pam_d_login').with({
           'ensure' => 'file',
@@ -640,8 +642,9 @@ session     required      pam_unix.so
         })
       }
     end
+  end
 
-  context 'pam_password_auth_ac set to a non absolute path' do
+  context 'pam_password_auth_ac set to a non absolute path on osfamily RedHat with operatingsystemmajrelease 6' do
     let(:params) { { :pam_password_auth_ac => 'invalid/path' } }
     let(:facts) do
       { :osfamily          => 'RedHat',
@@ -654,7 +657,239 @@ session     required      pam_unix.so
         should contain_class('pam')
       }.to raise_error(Puppet::Error)
     end
-  end
+
+    context 'with login_pam_access => sufficient on osfamily RedHat with operatingsystemmajrelease 6' do
+      let :facts do
+        {
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '6',
+        }
+      end
+
+      let(:params) {{ :login_pam_access => 'sufficient' }}
+
+      it { should contain_file('pam_d_login').with_content("#%PAM-1.0
+auth [user_unknown=ignore success=ok ignore=ignore default=bad] pam_securetty.so
+auth       include      system-auth
+account    required     pam_nologin.so
+account    include      system-auth
+account    sufficient     pam_access.so
+password   include      system-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+session    optional     pam_console.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open
+session    required     pam_namespace.so
+session    optional     pam_keyinit.so force revoke
+session    include      system-auth
+-session   optional     pam_ck_connector.so
+")
+      }
+    end
+
+    context 'with sshd_pam_access => sufficient on osfamily RedHat with operatingsystemmajrelease 6' do
+      let :facts do
+        {
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '6',
+        }
+      end
+
+      let(:params) {{ :sshd_pam_access => 'sufficient' }}
+
+      it { should contain_file('pam_d_sshd').with_content("#%PAM-1.0
+auth       required     pam_sepermit.so
+auth       include      password-auth
+account    sufficient     pam_access.so
+account    required     pam_nologin.so
+account    include      password-auth
+password   include      password-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open env_params
+session    optional     pam_keyinit.so force revoke
+session    include      password-auth
+")
+      }
+    end
+
+    context 'with login_pam_access => absent on osfamily RedHat with operatingsystemmajrelease 6' do
+      let :facts do
+        {
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '6',
+        }
+      end
+
+      let(:params) {{ :login_pam_access => 'absent' }}
+
+      it { should contain_file('pam_d_login').with_content("#%PAM-1.0
+auth [user_unknown=ignore success=ok ignore=ignore default=bad] pam_securetty.so
+auth       include      system-auth
+account    required     pam_nologin.so
+account    include      system-auth
+password   include      system-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+session    optional     pam_console.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open
+session    required     pam_namespace.so
+session    optional     pam_keyinit.so force revoke
+session    include      system-auth
+-session   optional     pam_ck_connector.so
+")
+      }
+    end
+
+    context 'with sshd_pam_access => absent on osfamily RedHat with operatingsystemmajrelease 6' do
+      let :facts do
+        {
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '6',
+        }
+      end
+
+      let(:params) {{ :sshd_pam_access => 'absent' }}
+
+      it { should contain_file('pam_d_sshd').with_content("#%PAM-1.0
+auth       required     pam_sepermit.so
+auth       include      password-auth
+account    required     pam_nologin.so
+account    include      password-auth
+password   include      password-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open env_params
+session    optional     pam_keyinit.so force revoke
+session    include      password-auth
+")
+      }
+    end
+
+    context 'with default params on osfamily RedHat with operatingsystemmajrelease 7' do
+      let :facts do
+        {
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '7',
+        }
+      end
+
+      it {
+        should contain_file('pam_system_auth_ac').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/pam.d/system-auth-ac',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+        })
+      }
+      it { should contain_file('pam_system_auth_ac').with_content("# This file is being maintained by Puppet.
+# DO NOT EDIT
+# Auth
+auth        required      pam_env.so
+auth        sufficient    pam_fprintd.so
+auth        sufficient    pam_unix.so nullok try_first_pass
+auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success
+auth        required      pam_deny.so
+
+# Account
+account     required      pam_unix.so
+account     sufficient    pam_localuser.so
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
+account     required      pam_permit.so
+
+# Password
+password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
+password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok
+password    required      pam_deny.so
+
+# Session
+session     optional      pam_keyinit.so revoke
+session     required      pam_limits.so
+-session    optional      pam_systemd.so
+session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
+session     required      pam_unix.so
+")
+      }
+
+      it {
+        should contain_file('pam_system_auth').with({
+          'ensure' => 'symlink',
+          'path'   => '/etc/pam.d/system-auth',
+          'owner'  => 'root',
+          'group'  => 'root',
+        })
+      }
+
+      it {
+        should contain_file('pam_d_login').with({
+          'ensure' => 'file',
+          'path'   => '/etc/pam.d/login',
+          'owner'  => 'root',
+          'group'  => 'root',
+          'mode'   => '0644',
+        })
+      }
+
+      it { should contain_file('pam_d_login').with_content("#%PAM-1.0
+auth [user_unknown=ignore success=ok ignore=ignore default=bad] pam_securetty.so
+auth       substack     system-auth
+auth       include      postlogin
+account    required     pam_nologin.so
+account    include      system-auth
+password   include      system-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+session    optional     pam_console.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open
+session    required     pam_namespace.so
+session    optional     pam_keyinit.so force revoke
+session    include      system-auth
+session    include      postlogin
+-session   optional     pam_ck_connector.so
+")
+      }
+
+      it {
+        should contain_file('pam_d_sshd').with({
+          'ensure' => 'file',
+          'path'   => '/etc/pam.d/sshd',
+          'owner'  => 'root',
+          'group'  => 'root',
+          'mode'   => '0644',
+        })
+      }
+
+      it { should contain_file('pam_d_sshd').with_content("#%PAM-1.0
+auth       required     pam_sepermit.so
+auth       substack     password-auth
+auth       include      postlogin
+account    required     pam_nologin.so
+account    include      password-auth
+password   include      password-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open env_params
+session    optional     pam_keyinit.so force revoke
+session    include      password-auth
+session    include      postlogin
+")
+      }
+
+      it { should_not contain_file('pam_system_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so/) }
+    end
 
     context 'with default params on Ubuntu 12.04 LTS' do
       let :facts do
@@ -1587,6 +1822,21 @@ session required        pam_unix_session.so.1
       it { should contain_file('pam_system_auth_ac').with_content(/password[\s]+sufficient[\s]+pam_vas3.so/) }
       it { should contain_file('pam_system_auth_ac').with_content(/session[\s]+required[\s]+pam_vas3.so/) }
       it { should_not contain_file('pam_system_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so.*store_creds/) }
+      it {
+        should contain_file('pam_password_auth_ac').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/pam.d/password-auth-ac',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+        })
+      }
+
+      it { should contain_file('pam_password_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so create_homedir get_nonvas_pass/) }
+      it { should contain_file('pam_password_auth_ac').with_content(/account[\s]+sufficient[\s]+pam_vas3.so/) }
+      it { should contain_file('pam_password_auth_ac').with_content(/password[\s]+sufficient[\s]+pam_vas3.so/) }
+      it { should contain_file('pam_password_auth_ac').with_content(/session[\s]+required[\s]+pam_limits.so/) }
+      it { should_not contain_file('pam_password_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so.*store_creds/) }
     end
 
     context 'with ensure_vas=present and default vas_major_version (4) on osfamily RedHat with operatingsystemmajrelease 7' do
@@ -1617,21 +1867,6 @@ session required        pam_unix_session.so.1
       it { should contain_file('pam_system_auth_ac').with_content(/password[\s]+sufficient[\s]+pam_vas3.so/) }
       it { should contain_file('pam_system_auth_ac').with_content(/session[\s]+required[\s]+pam_vas3.so/) }
       it { should_not contain_file('pam_system_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so.*store_creds/) }
-      it {
-        should contain_file('pam_password_auth_ac').with({
-          'ensure'  => 'file',
-          'path'    => '/etc/pam.d/password-auth-ac',
-          'owner'   => 'root',
-          'group'   => 'root',
-          'mode'    => '0644',
-        })
-      }
-
-      it { should contain_file('pam_password_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so create_homedir get_nonvas_pass/) }
-      it { should contain_file('pam_password_auth_ac').with_content(/account[\s]+sufficient[\s]+pam_vas3.so/) }
-      it { should contain_file('pam_password_auth_ac').with_content(/password[\s]+sufficient[\s]+pam_vas3.so/) }
-      it { should contain_file('pam_password_auth_ac').with_content(/session[\s]+required[\s]+pam_limits.so/) }
-      it { should_not contain_file('pam_password_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so.*store_creds/) }
     end
 
     context 'with ensure_vas=present and vas_major_version=3 on osfamily RedHat with operatingsystemmajrelease 5' do
@@ -1692,6 +1927,20 @@ session required        pam_unix_session.so.1
       it { should contain_file('pam_system_auth_ac').with_content(/account[\s]+sufficient[\s]+pam_vas3.so/) }
       it { should contain_file('pam_system_auth_ac').with_content(/password[\s]+sufficient[\s]+pam_vas3.so/) }
       it { should contain_file('pam_system_auth_ac').with_content(/session[\s]+required[\s]+pam_vas3.so/) }
+      it {
+        should contain_file('pam_password_auth_ac').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/pam.d/password-auth-ac',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+        })
+      }
+
+      it { should contain_file('pam_password_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so create_homedir get_nonvas_pass/) }
+      it { should contain_file('pam_password_auth_ac').with_content(/account[\s]+sufficient[\s]+pam_vas3.so/) }
+      it { should contain_file('pam_password_auth_ac').with_content(/password[\s]+sufficient[\s]+pam_vas3.so/) }
+      it { should contain_file('pam_password_auth_ac').with_content(/session[\s]+required[\s]+pam_vas3.so/) }
     end
 
     context 'with ensure_vas=present on osfamily Suse with lsbmajdistrelease 10' do
@@ -1747,7 +1996,7 @@ account  required    pam_unix2.so
           'owner'   => 'root',
           'group'   => 'root',
           'mode'    => '0644',
-         })
+        })
       }
 
       it { should contain_file('pam_common_password').with_content("# This file is being maintained by Puppet.
@@ -1766,7 +2015,7 @@ password  required    pam_unix2.so use_authtok nullok
           'owner'   => 'root',
           'group'   => 'root',
           'mode'    => '0644',
-         })
+        })
       }
 
       it { should contain_file('pam_common_session').with_content("# This file is being maintained by Puppet.
@@ -1811,24 +2060,14 @@ session   optional  pam_mail.so standard
         })
       }
 
-      it { should contain_file('pam_system_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so.*store_creds/) }
-      it { should contain_file('pam_system_auth_ac').with_content(/account[\s]+sufficient[\s]+pam_vas3.so/) }
-      it { should contain_file('pam_system_auth_ac').with_content(/password[\s]+sufficient[\s]+pam_vas3.so/) }
-      it { should contain_file('pam_system_auth_ac').with_content(/session[\s]+required[\s]+pam_vas3.so/) }
-      it {
-        should contain_file('pam_password_auth_ac').with({
-          'ensure'  => 'file',
-          'path'    => '/etc/pam.d/password-auth-ac',
-          'owner'   => 'root',
-          'group'   => 'root',
-          'mode'    => '0644',
-        })
+      it { should contain_file('pam_d_sshd').with_content("#%PAM-1.0
+auth      include   common-auth
+auth      required  pam_nologin.so
+account   include   common-account
+password  include   common-password
+session   include   common-session
+")
       }
-
-      it { should contain_file('pam_password_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so create_homedir get_nonvas_pass/) }
-      it { should contain_file('pam_password_auth_ac').with_content(/account[\s]+sufficient[\s]+pam_vas3.so/) }
-      it { should contain_file('pam_password_auth_ac').with_content(/password[\s]+sufficient[\s]+pam_vas3.so/) }
-      it { should contain_file('pam_password_auth_ac').with_content(/session[\s]+required[\s]+pam_vas3.so/) }
     end
 
     context 'with ensure_vas=present on osfamily Suse with lsbmajdistrelease 11' do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -530,7 +530,6 @@ session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet 
 session     required      pam_unix.so
 ")
       }
-
       it {
         should contain_file('pam_system_auth').with({
           'ensure' => 'symlink',
@@ -539,7 +538,6 @@ session     required      pam_unix.so
           'group'  => 'root',
         })
       }
-
       it {
         should contain_file('pam_d_login').with({
           'ensure' => 'file',
@@ -598,6 +596,49 @@ session    include      password-auth
       }
 
       it { should_not contain_file('pam_system_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so/) }
+      it {
+        should contain_file('pam_password_auth_ac').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/pam.d/password-auth-ac',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+        })
+      }
+	  it { should contain_file('pam_password_auth_ac').with_content("# This file is being maintained by Puppet.
+# DO NOT EDIT
+# Auth
+auth        required      pam_env.so
+auth        sufficient    pam_unix.so nullok try_first_pass
+auth        requisite     pam_succeed_if.so uid >= 500 quiet
+auth        required      pam_deny.so
+
+# Account
+account     required      pam_unix.so
+account     sufficient    pam_localuser.so
+account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     required      pam_permit.so
+
+# Password
+password    requisite     pam_cracklib.so try_first_pass retry=3 type=
+password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok
+password    required      pam_deny.so
+
+# Session
+session     optional      pam_keyinit.so revoke
+session     required      pam_limits.so
+session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
+session     required      pam_unix.so
+")
+      }
+	  it {
+        should contain_file('pam_password_auth').with({
+          'ensure' => 'symlink',
+          'path'   => '/etc/pam.d/password-auth',
+          'owner'  => 'root',
+          'group'  => 'root',
+        })
+      }
     end
 
     context 'with login_pam_access => sufficient on osfamily RedHat with operatingsystemmajrelease 6' do
@@ -1794,6 +1835,21 @@ session required        pam_unix_session.so.1
       it { should contain_file('pam_system_auth_ac').with_content(/password[\s]+sufficient[\s]+pam_vas3.so/) }
       it { should contain_file('pam_system_auth_ac').with_content(/session[\s]+required[\s]+pam_vas3.so/) }
       it { should_not contain_file('pam_system_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so.*store_creds/) }
+      it {
+        should contain_file('pam_password_auth_ac').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/pam.d/password-auth-ac',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+        })
+      }
+
+      it { should contain_file('pam_password_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so create_homedir get_nonvas_pass/) }
+      it { should contain_file('pam_password_auth_ac').with_content(/account[\s]+sufficient[\s]+pam_vas3.so/) }
+      it { should contain_file('pam_password_auth_ac').with_content(/password[\s]+sufficient[\s]+pam_vas3.so/) }
+      it { should contain_file('pam_password_auth_ac').with_content(/session[\s]+required[\s]+pam_limits.so/) }
+      it { should_not contain_file('pam_password_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so.*store_creds/) }
     end
 
     context 'with ensure_vas=present and vas_major_version=3 on osfamily RedHat with operatingsystemmajrelease 5' do
@@ -1973,14 +2029,24 @@ session   optional  pam_mail.so standard
         })
       }
 
-      it { should contain_file('pam_d_sshd').with_content("#%PAM-1.0
-auth      include   common-auth
-auth      required  pam_nologin.so
-account   include   common-account
-password  include   common-password
-session   include   common-session
-")
+      it { should contain_file('pam_system_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so.*store_creds/) }
+      it { should contain_file('pam_system_auth_ac').with_content(/account[\s]+sufficient[\s]+pam_vas3.so/) }
+      it { should contain_file('pam_system_auth_ac').with_content(/password[\s]+sufficient[\s]+pam_vas3.so/) }
+      it { should contain_file('pam_system_auth_ac').with_content(/session[\s]+required[\s]+pam_vas3.so/) }
+      it {
+        should contain_file('pam_password_auth_ac').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/pam.d/password-auth-ac',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+        })
       }
+
+      it { should contain_file('pam_password_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so create_homedir get_nonvas_pass/) }
+      it { should contain_file('pam_password_auth_ac').with_content(/account[\s]+sufficient[\s]+pam_vas3.so/) }
+      it { should contain_file('pam_password_auth_ac').with_content(/password[\s]+sufficient[\s]+pam_vas3.so/) }
+      it { should contain_file('pam_password_auth_ac').with_content(/session[\s]+required[\s]+pam_vas3.so/) }
     end
 
     context 'with ensure_vas=present on osfamily Suse with lsbmajdistrelease 11' do

--- a/templates/password-auth-ac.erb
+++ b/templates/password-auth-ac.erb
@@ -1,0 +1,21 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+# Auth
+<% @my_pam_password_auth_lines.each do |auth_line| -%>
+<%= auth_line %>
+<% end -%>
+
+# Account
+<% @my_pam_password_account_lines.each do |account_line| -%>
+<%= account_line %>
+<% end -%>
+
+# Password
+<% @my_pam_password_pswd_lines.each do |password_line| -%>
+<%= password_line %>
+<% end -%>
+
+# Session
+<% @my_pam_password_session_lines.each do |session_line| -%>
+<%= session_line %>
+<% end -%>


### PR DESCRIPTION
Pam config for RHEL6 uses both system-auth and password-auth but the module only manages system-auth