### PR TITLE
Add login_pam_access and sshd_pam_access parameters

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,8 @@
 #
 class pam (
   $allowed_users                       = 'root',
+  $login_pam_access                    = 'required',
+  $sshd_pam_access                     = 'required',
   $ensure_vas                          = 'absent',
   $package_name                        = undef,
   $pam_conf_file                       = '/etc/pam.conf',
@@ -754,6 +756,11 @@ class pam (
       fail("Pam is only supported on RedHat, Suse, Debian and Solaris osfamilies. Your osfamily is identified as <${::osfamily}>.")
     }
   }
+
+  $valid_pam_access_values = ['^required$', '^requisite$', '^sufficient$', '^optional$', '^absent$']
+
+  validate_re($login_pam_access, $valid_pam_access_values)
+  validate_re($sshd_pam_access, $valid_pam_access_values)
 
   if $package_name == undef {
     $my_package_name = $default_package_name

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -384,6 +384,108 @@ session    required     pam_loginuid.so
       it { should_not contain_file('pam_system_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so/) }
     end
 
+    context 'with login_pam_access => sufficient on osfamily RedHat with operatingsystemmajrelease 5' do
+      let :facts do
+        {
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '5',
+        }
+      end
+
+      let(:params) {{ :login_pam_access => 'sufficient' }}
+
+      it { should contain_file('pam_d_login').with_content("#%PAM-1.0
+auth [user_unknown=ignore success=ok ignore=ignore default=bad] pam_securetty.so
+auth       include      system-auth
+account    required     pam_nologin.so
+account    include      system-auth
+account    sufficient     pam_access.so
+password   include      system-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    optional     pam_keyinit.so force revoke
+session    required     pam_loginuid.so
+session    include      system-auth
+session    optional     pam_console.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open
+")
+      }
+    end
+
+    context 'with sshd_pam_access => sufficient on osfamily RedHat with operatingsystemmajrelease 5' do
+      let :facts do
+        {
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '5',
+        }
+      end
+
+      let(:params) {{ :sshd_pam_access => 'sufficient' }}
+
+      it { should contain_file('pam_d_sshd').with_content("#%PAM-1.0
+auth       include      system-auth
+account    required     pam_nologin.so
+account    include      system-auth
+account    sufficient     pam_access.so
+password   include      system-auth
+session    optional     pam_keyinit.so force revoke
+session    include      system-auth
+session    required     pam_loginuid.so
+")
+      }
+    end
+
+    context 'with login_pam_access => absent on osfamily RedHat with operatingsystemmajrelease 5' do
+      let :facts do
+        {
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '5',
+        }
+      end
+
+      let(:params) {{ :login_pam_access => 'absent' }}
+
+      it { should contain_file('pam_d_login').with_content("#%PAM-1.0
+auth [user_unknown=ignore success=ok ignore=ignore default=bad] pam_securetty.so
+auth       include      system-auth
+account    required     pam_nologin.so
+account    include      system-auth
+password   include      system-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    optional     pam_keyinit.so force revoke
+session    required     pam_loginuid.so
+session    include      system-auth
+session    optional     pam_console.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open
+")
+      }
+    end
+
+    context 'with sshd_pam_access => sufficient on osfamily RedHat with operatingsystemmajrelease 5' do
+      let :facts do
+        {
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '5',
+        }
+      end
+
+      let(:params) {{ :sshd_pam_access => 'absent' }}
+
+      it { should contain_file('pam_d_sshd').with_content("#%PAM-1.0
+auth       include      system-auth
+account    required     pam_nologin.so
+account    include      system-auth
+password   include      system-auth
+session    optional     pam_keyinit.so force revoke
+session    include      system-auth
+session    required     pam_loginuid.so
+")
+      }
+    end
+
     context 'with default params on osfamily RedHat with operatingsystemmajrelease 6' do
       let :facts do
         {
@@ -496,6 +598,122 @@ session    include      password-auth
       }
 
       it { should_not contain_file('pam_system_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so/) }
+    end
+
+    context 'with login_pam_access => sufficient on osfamily RedHat with operatingsystemmajrelease 6' do
+      let :facts do
+        {
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '6',
+        }
+      end
+
+      let(:params) {{ :login_pam_access => 'sufficient' }}
+
+      it { should contain_file('pam_d_login').with_content("#%PAM-1.0
+auth [user_unknown=ignore success=ok ignore=ignore default=bad] pam_securetty.so
+auth       include      system-auth
+account    required     pam_nologin.so
+account    include      system-auth
+account    sufficient     pam_access.so
+password   include      system-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+session    optional     pam_console.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open
+session    required     pam_namespace.so
+session    optional     pam_keyinit.so force revoke
+session    include      system-auth
+-session   optional     pam_ck_connector.so
+")
+      }
+    end
+
+    context 'with sshd_pam_access => sufficient on osfamily RedHat with operatingsystemmajrelease 6' do
+      let :facts do
+        {
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '6',
+        }
+      end
+
+      let(:params) {{ :sshd_pam_access => 'sufficient' }}
+
+      it { should contain_file('pam_d_sshd').with_content("#%PAM-1.0
+auth       required     pam_sepermit.so
+auth       include      password-auth
+account    sufficient     pam_access.so
+account    required     pam_nologin.so
+account    include      password-auth
+password   include      password-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open env_params
+session    optional     pam_keyinit.so force revoke
+session    include      password-auth
+")
+      }
+    end
+
+    context 'with login_pam_access => absent on osfamily RedHat with operatingsystemmajrelease 6' do
+      let :facts do
+        {
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '6',
+        }
+      end
+
+      let(:params) {{ :login_pam_access => 'absent' }}
+
+      it { should contain_file('pam_d_login').with_content("#%PAM-1.0
+auth [user_unknown=ignore success=ok ignore=ignore default=bad] pam_securetty.so
+auth       include      system-auth
+account    required     pam_nologin.so
+account    include      system-auth
+password   include      system-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+session    optional     pam_console.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open
+session    required     pam_namespace.so
+session    optional     pam_keyinit.so force revoke
+session    include      system-auth
+-session   optional     pam_ck_connector.so
+")
+      }
+    end
+
+    context 'with sshd_pam_access => absent on osfamily RedHat with operatingsystemmajrelease 6' do
+      let :facts do
+        {
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '6',
+        }
+      end
+
+      let(:params) {{ :sshd_pam_access => 'absent' }}
+
+      it { should contain_file('pam_d_sshd').with_content("#%PAM-1.0
+auth       required     pam_sepermit.so
+auth       include      password-auth
+account    required     pam_nologin.so
+account    include      password-auth
+password   include      password-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open env_params
+session    optional     pam_keyinit.so force revoke
+session    include      password-auth
+")
+      }
     end
 
     context 'with default params on osfamily RedHat with operatingsystemmajrelease 7' do
@@ -1083,6 +1301,102 @@ session   optional       pam_ck_connector.so
 auth      requisite      pam_nologin.so
 auth      include        common-auth
 account   required       pam_access.so
+account   requisite      pam_nologin.so
+account   include        common-account
+password  include        common-password
+session   required       pam_loginuid.so
+session   include        common-session
+")
+      }
+    end
+
+    context 'with login_pam_access => sufficient on osfamily Suse with lsbmajdistrelease 11' do
+      let :facts do
+        {
+          :osfamily          => 'Suse',
+          :lsbmajdistrelease => '11',
+        }
+      end
+
+      let(:params) {{ :login_pam_access => 'sufficient' }}
+
+      it { should contain_file('pam_d_login').with_content("#%PAM-1.0
+auth      requisite      pam_nologin.so
+auth      [user_unknown=ignore success=ok ignore=ignore auth_err=die default=bad]        pam_securetty.so
+auth      include        common-auth
+account   include        common-account
+account   sufficient       pam_access.so
+password  include        common-password
+session   required       pam_loginuid.so
+session   include        common-session
+session   required       pam_lastlog.so  nowtmp
+session   optional       pam_mail.so standard
+session   optional       pam_ck_connector.so
+")
+      }
+    end
+
+    context 'with sshd_pam_access => sufficient on osfamily Suse with lsbmajdistrelease 11' do
+      let :facts do
+        {
+          :osfamily          => 'Suse',
+          :lsbmajdistrelease => '11',
+        }
+      end
+
+      let(:params) {{ :sshd_pam_access => 'sufficient' }}
+
+      it { should contain_file('pam_d_sshd').with_content("#%PAM-1.0
+auth      requisite      pam_nologin.so
+auth      include        common-auth
+account   sufficient       pam_access.so
+account   requisite      pam_nologin.so
+account   include        common-account
+password  include        common-password
+session   required       pam_loginuid.so
+session   include        common-session
+")
+      }
+    end
+
+    context 'with login_pam_access => absent on osfamily Suse with lsbmajdistrelease 11' do
+      let :facts do
+        {
+          :osfamily          => 'Suse',
+          :lsbmajdistrelease => '11',
+        }
+      end
+
+      let(:params) {{ :login_pam_access => 'absent' }}
+
+      it { should contain_file('pam_d_login').with_content("#%PAM-1.0
+auth      requisite      pam_nologin.so
+auth      [user_unknown=ignore success=ok ignore=ignore auth_err=die default=bad]        pam_securetty.so
+auth      include        common-auth
+account   include        common-account
+password  include        common-password
+session   required       pam_loginuid.so
+session   include        common-session
+session   required       pam_lastlog.so  nowtmp
+session   optional       pam_mail.so standard
+session   optional       pam_ck_connector.so
+")
+      }
+    end
+
+    context 'with sshd_pam_access => absent on osfamily Suse with lsbmajdistrelease 11' do
+      let :facts do
+        {
+          :osfamily          => 'Suse',
+          :lsbmajdistrelease => '11',
+        }
+      end
+
+      let(:params) {{ :sshd_pam_access => 'absent' }}
+
+      it { should contain_file('pam_d_sshd').with_content("#%PAM-1.0
+auth      requisite      pam_nologin.so
+auth      include        common-auth
 account   requisite      pam_nologin.so
 account   include        common-account
 password  include        common-password

--- a/templates/login.el5.erb
+++ b/templates/login.el5.erb
@@ -3,7 +3,9 @@ auth [user_unknown=ignore success=ok ignore=ignore default=bad] pam_securetty.so
 auth       include      system-auth
 account    required     pam_nologin.so
 account    include      system-auth
-account    required     pam_access.so
+<% if @login_pam_access != 'absent' -%>
+account    <%= @login_pam_access %>     pam_access.so
+<% end -%>
 password   include      system-auth
 # pam_selinux.so close should be the first session rule
 session    required     pam_selinux.so close

--- a/templates/login.el6.erb
+++ b/templates/login.el6.erb
@@ -3,7 +3,9 @@ auth [user_unknown=ignore success=ok ignore=ignore default=bad] pam_securetty.so
 auth       include      system-auth
 account    required     pam_nologin.so
 account    include      system-auth
-account    required     pam_access.so
+<% if @login_pam_access != 'absent' -%>
+account    <%= @login_pam_access %>     pam_access.so
+<% end -%>
 password   include      system-auth
 # pam_selinux.so close should be the first session rule
 session    required     pam_selinux.so close

--- a/templates/login.suse11.erb
+++ b/templates/login.suse11.erb
@@ -3,7 +3,9 @@ auth      requisite      pam_nologin.so
 auth      [user_unknown=ignore success=ok ignore=ignore auth_err=die default=bad]        pam_securetty.so
 auth      include        common-auth
 account   include        common-account
-account   required       pam_access.so
+<% if @login_pam_access != 'absent' -%>
+account   <%= @login_pam_access %>       pam_access.so
+<% end -%>
 password  include        common-password
 session   required       pam_loginuid.so
 session   include        common-session

--- a/templates/sshd.el5.erb
+++ b/templates/sshd.el5.erb
@@ -2,7 +2,9 @@
 auth       include      system-auth
 account    required     pam_nologin.so
 account    include      system-auth
-account    required     pam_access.so
+<% if @sshd_pam_access != 'absent' -%>
+account    <%= @sshd_pam_access %>     pam_access.so
+<% end -%>
 password   include      system-auth
 session    optional     pam_keyinit.so force revoke
 session    include      system-auth

--- a/templates/sshd.el6.erb
+++ b/templates/sshd.el6.erb
@@ -1,7 +1,9 @@
 #%PAM-1.0
 auth       required     pam_sepermit.so
 auth       include      password-auth
-account    required     pam_access.so
+<% if @sshd_pam_access != 'absent' -%>
+account    <%= @sshd_pam_access %>     pam_access.so
+<% end -%>
 account    required     pam_nologin.so
 account    include      password-auth
 password   include      password-auth

--- a/templates/sshd.suse11.erb
+++ b/templates/sshd.suse11.erb
@@ -1,7 +1,9 @@
 #%PAM-1.0
 auth      requisite      pam_nologin.so
 auth      include        common-auth
-account   required       pam_access.so
+<% if @sshd_pam_access != 'absent' -%>
+account   <%= @sshd_pam_access %>       pam_access.so
+<% end -%>
 account   requisite      pam_nologin.so
 account   include        common-account
 password  include        common-password


### PR DESCRIPTION
Add login_pam_access and sshd_pam_access parameters to override the control flag for pam_access.so when used in sshd.conf or login.conf templates (EL5, EL6 and SUSE 11)

This is particularly useful as I need to have pam_access set to "sufficient" in some cases when another PAM module is in charge of access control (pam_slurm.so).

I moved the tests for File[pam_d_login] and File[pam_d_sshd] resource to separate files for the sake of reducing the size of init_spec.rb.  Even with a good IDE it's sometimes hard to find things in a file over 1500 lines long.