### PR TITLE
Update init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,7 +43,10 @@ class pam (
   $vas_major_version                   = '4',
 ) {
 
-  include nsswitch
+# If puppet-module-nsswitch is installed, set the defaults from there 
+if defined('nsswitch') { 
+  include nsswitch 
+} 
 
   case $::osfamily {
     'RedHat': {


### PR DESCRIPTION
In our organisation, we don't need all of the functionality of the puppet nsswitch module.

This change wraps a condition around the nsswitch include, and if nsswitch module doesn't exist, silently ignore the include instead.

I believe this change is backward compatible.

ptionally include nsswitch module if its installed.