### PR TITLE
Order hash for access.conf, useful for Ruby 1.8.7

### DIFF
--- a/templates/access.conf.erb
+++ b/templates/access.conf.erb
@@ -7,7 +7,8 @@
 entries = scope.lookupvar('pam::allowed_users')
 -%>
 <% if entries.is_a? Hash -%>
-<% entries.each do |key, value| -%>
+<% entries.keys.sort.each do |key| -%>
+<% value = entries[key] -%>
 + : <%= key %> : <% if value.is_a? Array -%><%= value.join(' ') %><% elsif value.is_a? String -%><%= value %><% else -%>ALL<% end %>
 <% end -%>
 <% elsif entries.is_a? Array -%>


### PR DESCRIPTION
Thanks to Treydock for pointing this out! Prior to this commit, if you
specify allowed_users as a hash with Ruby 1.8.7 it would change the
order and show your puppet runs as having changes.