### PR TITLE
Replace lsbmajdistrelease fact check with operatingsystemmajrelease for ...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,7 +47,7 @@ class pam (
 
   case $::osfamily {
     'RedHat': {
-      case $::lsbmajdistrelease {
+      case $::operatingsystemmajrelease {
         '5': {
           $default_pam_d_login_template = 'pam/login.el5.erb'
           $default_pam_d_sshd_template  = 'pam/sshd.el5.erb'
@@ -300,7 +300,7 @@ class pam (
           }
         }
         default: {
-          fail("Pam is only supported on EL 5, 6 and 7. Your lsbmajdistrelease is identified as <${::lsbmajdistrelease}>.")
+          fail("Pam is only supported on EL 5, 6 and 7. Your operatingsystemmajrelease is identified as <${::operatingsystemmajrelease}>.")
         }
       }
     }

--- a/spec/classes/accesslogin_spec.rb
+++ b/spec/classes/accesslogin_spec.rb
@@ -4,8 +4,8 @@ describe 'pam::accesslogin' do
     context 'with default values on supported platform' do
       let(:facts) do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '5',
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
         }
       end
 
@@ -40,8 +40,8 @@ describe 'pam::accesslogin' do
     context 'with multiple users on supported platform expressed as an array' do
       let(:facts) do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '5',
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
         }
       end
       let(:pre_condition) do
@@ -80,8 +80,8 @@ describe 'pam::accesslogin' do
     context 'with hash entry containing string values' do
       let(:facts) do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '5',
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
         }
       end
       let(:pre_condition) do
@@ -94,8 +94,8 @@ describe 'pam::accesslogin' do
     context 'with hash entry containing array of values' do
       let(:facts) do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '5',
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
         }
       end
       let(:pre_condition) do
@@ -107,8 +107,8 @@ describe 'pam::accesslogin' do
     context 'with hash entry containing no value should default to "ALL"' do
       let(:facts) do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '5',
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
         }
       end
       let(:pre_condition) do
@@ -120,8 +120,8 @@ describe 'pam::accesslogin' do
     context 'with hash entries containing string, array and empty hash' do
       let(:facts) do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '5',
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
         }
       end
       let(:pre_condition) do
@@ -137,8 +137,8 @@ describe 'pam::accesslogin' do
     context 'with custom values on supported platform' do
       let(:facts) do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '5',
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
         }
       end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -12,7 +12,7 @@ describe 'pam' do
       it 'should fail' do
         expect {
           should contain_class('pam')
-        }.to raise_error(Puppet::Error,/Pam is only supported on EL 5, 6 and 7. Your lsbmajdistrelease is identified as <4>./)
+        }.to raise_error(Puppet::Error,/Pam is only supported on EL 5, 6 and 7. Your Your operatingsystemmajrelease is identified as <4>./)
       end
     end
 
@@ -77,11 +77,11 @@ describe 'pam' do
 
   describe 'packages' do
 
-    context 'with default params on osfamily RedHat with lsbmajdistrelease 5' do
+    context 'with default params on osfamily RedHat with operatingsystemmajrelease 5' do
       let :facts do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '5',
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '5',
         }
       end
 
@@ -94,11 +94,11 @@ describe 'pam' do
       end
     end
 
-    context 'with default params on osfamily RedHat with lsbmajdistrelease 6' do
+    context 'with default params on osfamily RedHat with operatingsystemmajrelease 6' do
       let :facts do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '6',
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '6',
         }
       end
 
@@ -109,11 +109,11 @@ describe 'pam' do
       end
     end
 
-    context 'with default params on osfamily RedHat with lsbmajdistrelease 7' do
+    context 'with default params on osfamily RedHat with operatingsystemmajrelease 7' do
       let :facts do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '7',
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '7',
         }
       end
 
@@ -222,8 +222,8 @@ describe 'pam' do
     context 'with specifying package_name on valid platform' do
       let :facts do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '5',
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '5',
         }
       end
 
@@ -278,11 +278,11 @@ describe 'pam' do
 
     end
 
-    context 'with default params on osfamily RedHat with lsbmajdistrelease 5' do
+    context 'with default params on osfamily RedHat with operatingsystemmajrelease 5' do
       let :facts do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '5',
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '5',
         }
       end
 
@@ -384,11 +384,11 @@ session    required     pam_loginuid.so
       it { should_not contain_file('pam_system_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so/) }
     end
 
-    context 'with default params on osfamily RedHat with lsbmajdistrelease 6' do
+    context 'with default params on osfamily RedHat with operatingsystemmajrelease 6' do
       let :facts do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '6',
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '6',
         }
       end
 
@@ -498,11 +498,11 @@ session    include      password-auth
       it { should_not contain_file('pam_system_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so/) }
     end
 
-    context 'with default params on osfamily RedHat with lsbmajdistrelease 7' do
+    context 'with default params on osfamily RedHat with operatingsystemmajrelease 7' do
       let :facts do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '7',
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '7',
         }
       end
 
@@ -1392,7 +1392,7 @@ session required        pam_unix_session.so.1
       }
     end
 
-    context 'with ensure_vas=present and default vas_major_version (4) on osfamily RedHat with lsbmajdistrelease 5' do
+    context 'with ensure_vas=present and default vas_major_version (4) on osfamily RedHat with operatingsystemmajrelease 5' do
       let (:params) do
         {
           :ensure_vas => 'present',
@@ -1400,8 +1400,8 @@ session required        pam_unix_session.so.1
       end
       let :facts do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '5',
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '5',
         }
       end
 
@@ -1422,7 +1422,7 @@ session required        pam_unix_session.so.1
       it { should_not contain_file('pam_system_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so.*store_creds/) }
     end
 
-    context 'with ensure_vas=present and default vas_major_version (4) on osfamily RedHat with lsbmajdistrelease 6' do
+    context 'with ensure_vas=present and default vas_major_version (4) on osfamily RedHat with operatingsystemmajrelease 6' do
       let (:params) do
         {
           :ensure_vas => 'present',
@@ -1430,8 +1430,8 @@ session required        pam_unix_session.so.1
       end
       let :facts do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '6',
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '6',
         }
       end
 
@@ -1452,7 +1452,7 @@ session required        pam_unix_session.so.1
       it { should_not contain_file('pam_system_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so.*store_creds/) }
     end
 
-    context 'with ensure_vas=present and default vas_major_version (4) on osfamily RedHat with lsbmajdistrelease 7' do
+    context 'with ensure_vas=present and default vas_major_version (4) on osfamily RedHat with operatingsystemmajrelease 7' do
       let (:params) do
         {
           :ensure_vas => 'present',
@@ -1460,8 +1460,8 @@ session required        pam_unix_session.so.1
       end
       let :facts do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '7',
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '7',
         }
       end
 
@@ -1482,7 +1482,7 @@ session required        pam_unix_session.so.1
       it { should_not contain_file('pam_system_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so.*store_creds/) }
     end
 
-    context 'with ensure_vas=present and vas_major_version=3 on osfamily RedHat with lsbmajdistrelease 5' do
+    context 'with ensure_vas=present and vas_major_version=3 on osfamily RedHat with operatingsystemmajrelease 5' do
       let (:params) do
         {
           :ensure_vas        => 'present',
@@ -1491,8 +1491,8 @@ session required        pam_unix_session.so.1
       end
       let :facts do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '5',
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '5',
         }
       end
 
@@ -1512,7 +1512,7 @@ session required        pam_unix_session.so.1
       it { should contain_file('pam_system_auth_ac').with_content(/session[\s]+required[\s]+pam_vas3.so/) }
     end
 
-    context 'with ensure_vas=present and vas_major_version=3 on osfamily RedHat with lsbmajdistrelease 6' do
+    context 'with ensure_vas=present and vas_major_version=3 on osfamily RedHat with operatingsystemmajrelease 6' do
       let (:params) do
         {
           :ensure_vas        => 'present',
@@ -1521,8 +1521,8 @@ session required        pam_unix_session.so.1
       end
       let :facts do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '6',
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '6',
         }
       end
 
@@ -2274,7 +2274,7 @@ other   session  required        pam_unix_session.so.1
       }
     end
 
-    context 'with ensure_vas=present and unsupported vas_major_version on osfamily RedHat with lsbmajdistrelease 5' do
+    context 'with ensure_vas=present and unsupported vas_major_version on osfamily RedHat with operatingsystemmajrelease 5' do
       let (:params) do
         {
           :ensure_vas        => 'present',
@@ -2283,8 +2283,8 @@ other   session  required        pam_unix_session.so.1
       end
       let :facts do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '5',
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '5',
         }
       end
 
@@ -2295,7 +2295,7 @@ other   session  required        pam_unix_session.so.1
       end
     end
 
-    context 'with ensure_vas=present and unsupported vas_major_version on osfamily RedHat with lsbmajdistrelease 5' do
+    context 'with ensure_vas=present and unsupported vas_major_version on osfamily RedHat with operatingsystemmajrelease 5' do
       let (:params) do
         {
           :ensure_vas        => 'present',
@@ -2304,8 +2304,8 @@ other   session  required        pam_unix_session.so.1
       end
       let :facts do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '5',
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '5',
         }
       end
 
@@ -2316,7 +2316,7 @@ other   session  required        pam_unix_session.so.1
       end
     end
 
-    context 'with ensure_vas=present and unsupported vas_major_version on osfamily RedHat with lsbmajdistrelease 6' do
+    context 'with ensure_vas=present and unsupported vas_major_version on osfamily RedHat with operatingsystemmajrelease 6' do
       let (:params) do
         {
           :ensure_vas        => 'present',
@@ -2325,8 +2325,8 @@ other   session  required        pam_unix_session.so.1
       end
       let :facts do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '6',
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '6',
         }
       end
 
@@ -2337,7 +2337,7 @@ other   session  required        pam_unix_session.so.1
       end
     end
 
-    context 'with ensure_vas=present and unsupported vas_major_version on osfamily RedHat with lsbmajdistrelease 7' do
+    context 'with ensure_vas=present and unsupported vas_major_version on osfamily RedHat with operatingsystemmajrelease 7' do
       let (:params) do
         {
           :ensure_vas        => 'present',
@@ -2346,8 +2346,8 @@ other   session  required        pam_unix_session.so.1
       end
       let :facts do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '7',
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '7',
         }
       end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -4,15 +4,15 @@ describe 'pam' do
   describe 'on unsupported platforms' do
     context 'with defaults params on osfamily RedHat 4' do
       let(:facts) do
-        { :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '4',
+        { :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '4',
         }
       end
 
       it 'should fail' do
         expect {
           should contain_class('pam')
-        }.to raise_error(Puppet::Error,/Pam is only supported on EL 5, 6 and 7. Your Your operatingsystemmajrelease is identified as <4>./)
+        }.to raise_error(Puppet::Error,/Pam is only supported on EL 5, 6 and 7. Your operatingsystemmajrelease is identified as <4>./)
       end
     end
 

--- a/spec/classes/limits_spec.rb
+++ b/spec/classes/limits_spec.rb
@@ -149,8 +149,8 @@ describe 'pam::limits' do
         let(:params) { { :purge_limits_d_dir => value } }
         let(:facts) do
           {
-            :osfamily          => 'RedHat',
-            :lsbmajdistrelease => '5',
+            :osfamily                  => 'RedHat',
+            :operatingsystemmajrelease => '5',
           }
         end
 
@@ -174,8 +174,8 @@ describe 'pam::limits' do
         let(:params) { { :purge_limits_d_dir => value } }
         let(:facts) do
           {
-            :osfamily          => 'RedHat',
-            :lsbmajdistrelease => '5',
+            :osfamily                  => 'RedHat',
+            :operatingsystemmajrelease => '5',
           }
         end
 
@@ -230,8 +230,8 @@ describe 'pam::limits' do
       let(:params) { { :purge_limits_d_dir => 'invalid' } }
       let(:facts) do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '5',
+          :osfamily                  => 'RedHat',
+          :operatingsystemmajrelease => '5',
         }
       end
 

--- a/spec/classes/limits_spec.rb
+++ b/spec/classes/limits_spec.rb
@@ -4,8 +4,8 @@ describe 'pam::limits' do
     context 'ensure file exists with default values for params on a supported platform' do
       let(:facts) do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '5',
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
         }
       end
 
@@ -32,8 +32,8 @@ describe 'pam::limits' do
       end
       let(:facts) do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '5',
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
         }
       end
 
@@ -55,8 +55,8 @@ describe 'pam::limits' do
       let(:params) { { :config_file => 'custom/security/limits.conf' } }
       let(:facts) do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '5',
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
         }
       end
 
@@ -71,8 +71,8 @@ describe 'pam::limits' do
       let(:params) { { :config_file_mode => '666' } }
       let(:facts) do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '5',
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
         }
       end
 
@@ -88,8 +88,8 @@ describe 'pam::limits' do
     context 'ensure directory exists with default values for params on a supported platform' do
       let(:facts) do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '5',
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
         }
       end
 
@@ -114,8 +114,8 @@ describe 'pam::limits' do
     context 'ensure directory exists with custom values for params on a supported platform' do
       let(:facts) do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '5',
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
         }
       end
 
@@ -198,8 +198,8 @@ describe 'pam::limits' do
       let(:params) { { :limits_d_dir => 'custom/security/limits.d' } }
       let(:facts) do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '5',
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
         }
       end
 
@@ -214,8 +214,8 @@ describe 'pam::limits' do
       let(:params) { { :limits_d_dir_mode => '777' } }
       let(:facts) do
         {
-          :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '5',
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
         }
       end
 

--- a/spec/defines/limits/fragment_spec.rb
+++ b/spec/defines/limits/fragment_spec.rb
@@ -8,8 +8,8 @@ describe 'pam::limits::fragment' do
     }
     let(:facts) {
       {
-        :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '5',
+        :osfamily                   => 'RedHat',
+        :operatingsystemmajrelease  => '5',
       }
     }
 
@@ -36,8 +36,8 @@ describe 'pam::limits::fragment' do
     }
     let(:facts) {
       {
-        :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '5',
+        :osfamily                   => 'RedHat',
+        :operatingsystemmajrelease  => '5',
       }
     }
 
@@ -73,8 +73,8 @@ root soft nproc unlimited
     }
     let(:facts) {
       {
-        :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '5',
+        :osfamily                   => 'RedHat',
+        :operatingsystemmajrelease  => '5',
       }
     }
 
@@ -103,8 +103,8 @@ root soft nproc unlimited
     let(:title) { '80-nproc' }
     let(:facts) {
       {
-        :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '5',
+        :osfamily                   => 'RedHat',
+        :operatingsystemmajrelease  => '5',
       }
     }
 


### PR DESCRIPTION
...RedHat based systems.

The use of lsbmajdistrelease must remain for Suse until the operatingsystemmajrelease fact supports Suse.