### PR TITLE
EL 6 - Adding support for password-auth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,9 @@ matrix:
       env: PUPPET_GEM_VERSION="~> 4"
     - rvm: 1.8.7
       env: PUPPET_GEM_VERSION="~> 4" STRICT_VARIABLES="yes"
+    - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION="~> 4" STRICT_VARIABLES="yes"
+
 
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -27,4 +27,5 @@ gem 'puppet-lint-variable_contains_upcase'
 # rspec must be v2 for ruby 1.8.7
 if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
   gem 'rspec', '~> 2.0'
+  gem 'rake', '~> 10.0'
 end

--- a/README.md
+++ b/README.md
@@ -309,6 +309,41 @@ Content template of $system_auth_ac_file. If undef, parameter is set based on th
 
 - *Default*: undef, default is set based on OS version
 
+password_auth_file
+----------------
+Path to password-auth. Used on RedHat.
+
+- *Default*: '/etc/pam.d/password-auth'
+
+password_auth_ac_file
+-------------------
+Path to password-auth-ac. Used on RedHat.
+
+- *Default*: '/etc/pam.d/password-auth-ac'
+
+pam_password_auth_lines
+-------------------------
+Array of lines used in content template of $password_auth_ac_file. If undef, parameter is set based on defaults for the detected platform.
+
+- *Default*: undef, default is set based on OS version
+
+pam_password_account_lines
+----------------------------
+Array of lines used in content template of $password_auth_ac_file. If undef, parameter is set based on defaults for the detected platform.
+
+- *Default*: undef, default is set based on OS version
+
+pam_password_password_lines
+-----------------------------
+Array of lines used in content template of $password_auth_ac_file. If undef, parameter is set based on defaults for the detected platform.
+
+- *Default*: undef, default is set based on OS version
+
+pam_password_session_lines
+----------------------------
+Array of lines used in content template of $password_auth_ac_file. If undef, parameter is set based on defaults for the detected platform.
+
+- *Default*: undef, default is set based on OS version
 ===
 
 # define pam::accesslogin

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -166,7 +166,7 @@ class pam (
                   'auth    requisite       pam_vas3.so echo_return',
                   'auth    sufficient      pam_unix.so nullok try_first_pass use_first_pass',
                   'auth    requisite       pam_succeed_if.so uid >= 500 quiet',
-                  'auth    required        pam_deny.so'
+                  'auth    required        pam_deny.so',
                 ]
               }
               '4': {
@@ -184,7 +184,7 @@ class pam (
                   'auth    requisite       pam_vas3.so echo_return',
                   'auth    sufficient      pam_unix.so nullok try_first_pass use_first_pass',
                   'auth    requisite       pam_succeed_if.so uid >= 500 quiet',
-                  'auth    required        pam_deny.so'
+                  'auth    required        pam_deny.so',
                 ]
               }
               default: {
@@ -223,7 +223,7 @@ class pam (
               'account required        pam_unix.so',
               'account sufficient      pam_localuser.so',
               'account sufficient      pam_succeed_if.so uid < 500 quiet',
-              'account required        pam_permit.so'
+              'account required        pam_permit.so',
             ]
 
             $default_pam_password_password_lines = [
@@ -231,7 +231,7 @@ class pam (
               'password        requisite       pam_vas3.so echo_return',
               'password        requisite       pam_cracklib.so try_first_pass retry=3 type=',
               'password        sufficient      pam_unix.so md5 shadow nullok try_first_pass use_authtok',
-              'password        required        pam_deny.so'
+              'password        required        pam_deny.so',
             ]
 
             $default_pam_password_session_lines = [
@@ -240,7 +240,7 @@ class pam (
               'session [success=1 default=ignore]      pam_succeed_if.so service in crond quiet use_uid',
               'session required        pam_vas3.so create_homedir',
               'session requisite       pam_vas3.so echo_return',
-              'session required        pam_unix.so'
+              'session required        pam_unix.so',
             ]
 
           } else {
@@ -256,7 +256,7 @@ class pam (
               'auth        required      pam_env.so',
               'auth        sufficient    pam_unix.so nullok try_first_pass',
               'auth        requisite     pam_succeed_if.so uid >= 500 quiet',
-              'auth        required      pam_deny.so'
+              'auth        required      pam_deny.so',
             ]
 
             $default_pam_account_lines = [
@@ -282,20 +282,20 @@ class pam (
               'account     required      pam_unix.so',
               'account     sufficient    pam_localuser.so',
               'account     sufficient    pam_succeed_if.so uid < 500 quiet',
-              'account     required      pam_permit.so'
+              'account     required      pam_permit.so',
             ]
 
             $default_pam_password_password_lines = [
               'password    requisite     pam_cracklib.so try_first_pass retry=3 type=',
-              'password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok',
-              'password    required      pam_deny.so'
+              'password    sufficient    pam_unix.so md5 shadow nullok try_first_pass use_authtok',
+              'password    required      pam_deny.so',
             ]
 
             $default_pam_password_session_lines = [
               'session     optional      pam_keyinit.so revoke',
               'session     required      pam_limits.so',
               'session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid',
-              'session     required      pam_unix.so'
+              'session     required      pam_unix.so',
             ]
           }
         }
@@ -321,7 +321,7 @@ class pam (
                   'auth    requisite       pam_vas3.so echo_return',
                   'auth    sufficient      pam_unix.so nullok try_first_pass use_first_pass',
                   'auth    requisite       pam_succeed_if.so uid >= 1000 quiet_success',
-                  'auth    required        pam_deny.so'
+                  'auth    required        pam_deny.so',
                 ]
               }
               default: {
@@ -361,7 +361,7 @@ class pam (
               'account required        pam_unix.so',
               'account sufficient      pam_localuser.so',
               'account sufficient      pam_succeed_if.so uid < 1000 quiet',
-              'account required        pam_permit.so'
+              'account required        pam_permit.so',
             ]
 
             $default_pam_password_password_lines = [
@@ -369,7 +369,7 @@ class pam (
               'password        sufficient      pam_vas3.so',
               'password        requisite       pam_vas3.so echo_return',
               'password        sufficient      pam_unix.so md5 shadow nullok try_first_pass use_authtok',
-              'password        required        pam_deny.so'
+              'password        required        pam_deny.so',
             ]
 
             $default_pam_password_session_lines = [
@@ -379,7 +379,7 @@ class pam (
               'session [success=1 default=ignore]      pam_succeed_if.so service in crond quiet use_uid',
               'session required        pam_vas3.so create_homedir',
               'session requisite       pam_vas3.so echo_return',
-              'session required        pam_unix.so'
+              'session required        pam_unix.so',
             ]
           } else {
             $default_pam_auth_lines = [
@@ -394,7 +394,7 @@ class pam (
               'auth        required      pam_env.so',
               'auth        sufficient    pam_unix.so nullok try_first_pass',
               'auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success',
-              'auth        required      pam_deny.so'
+              'auth        required      pam_deny.so',
             ]
 
             $default_pam_account_lines = [
@@ -421,20 +421,20 @@ class pam (
               'account     required      pam_unix.so',
               'account     sufficient    pam_localuser.so',
               'account     sufficient    pam_succeed_if.so uid < 1000 quiet',
-              'account     required      pam_permit.so'
+              'account     required      pam_permit.so',
             ]
 
             $default_pam_password_password_lines = [
               'password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=',
-              'password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok',
-              'password    required      pam_deny.so'
+              'password    sufficient    pam_unix.so md5 shadow nullok try_first_pass use_authtok',
+              'password    required      pam_deny.so',
             ]
             $default_pam_password_session_lines = [
               'session     optional      pam_keyinit.so revoke',
               'session     required      pam_limits.so',
               '-session     optional      pam_systemd.so',
               'session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid',
-              'session     required      pam_unix.so'
+              'session     required      pam_unix.so',
             ]
           }
         }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,12 @@ class pam (
   $common_session_noninteractive_file  = '/etc/pam.d/common-session-noninteractive',
   $system_auth_file                    = '/etc/pam.d/system-auth',
   $system_auth_ac_file                 = '/etc/pam.d/system-auth-ac',
+  $password_auth_file                  = '/etc/pam.d/password-auth',
+  $password_auth_ac_file               = '/etc/pam.d/password-auth-ac',
+  $pam_password_auth_lines             = undef,
+  $pam_password_account_lines          = undef,
+  $pam_password_password_lines         = undef,
+  $pam_password_session_lines          = undef,
   $system_auth_ac_auth_lines           = undef,
   $system_auth_ac_account_lines        = undef,
   $system_auth_ac_password_lines       = undef,
@@ -154,6 +160,14 @@ class pam (
                   'auth        requisite     pam_succeed_if.so uid >= 500 quiet',
                   'auth        required      pam_deny.so',
                 ]
+                $default_pam_password_auth_lines = [
+                  'auth    required        pam_env.so',
+                  'auth    sufficient      pam_vas3.so create_homedir get_nonvas_pass',
+                  'auth    requisite       pam_vas3.so echo_return',
+                  'auth    sufficient      pam_unix.so nullok try_first_pass use_first_pass',
+                  'auth    requisite       pam_succeed_if.so uid >= 500 quiet',
+                  'auth    required        pam_deny.so'
+                ]
               }
               '4': {
                 $default_pam_auth_lines = [
@@ -163,6 +177,14 @@ class pam (
                   'auth        sufficient    pam_unix.so nullok try_first_pass use_first_pass',
                   'auth        requisite     pam_succeed_if.so uid >= 500 quiet',
                   'auth        required      pam_deny.so',
+                ]
+                $default_pam_password_auth_lines = [
+                  'auth    required        pam_env.so',
+                  'auth    sufficient      pam_vas3.so create_homedir get_nonvas_pass',
+                  'auth    requisite       pam_vas3.so echo_return',
+                  'auth    sufficient      pam_unix.so nullok try_first_pass use_first_pass',
+                  'auth    requisite       pam_succeed_if.so uid >= 500 quiet',
+                  'auth    required        pam_deny.so'
                 ]
               }
               default: {
@@ -195,6 +217,32 @@ class pam (
               'session     requisite     pam_vas3.so echo_return',
               'session     required      pam_unix.so',
             ]
+            $default_pam_password_account_lines = [
+              'account sufficient      pam_vas3.so',
+              'account requisite       pam_vas3.so echo_return',
+              'account required        pam_unix.so',
+              'account sufficient      pam_localuser.so',
+              'account sufficient      pam_succeed_if.so uid < 500 quiet',
+              'account required        pam_permit.so'
+            ]
+
+            $default_pam_password_password_lines = [
+              'password        sufficient      pam_vas3.so',
+              'password        requisite       pam_vas3.so echo_return',
+              'password        requisite       pam_cracklib.so try_first_pass retry=3 type=',
+              'password        sufficient      pam_unix.so md5 shadow nullok try_first_pass use_authtok',
+              'password        required        pam_deny.so'
+            ]
+
+            $default_pam_password_session_lines = [
+              'session optional        pam_keyinit.so revoke',
+              'session required        pam_limits.so',
+              'session [success=1 default=ignore]      pam_succeed_if.so service in crond quiet use_uid',
+              'session required        pam_vas3.so create_homedir',
+              'session requisite       pam_vas3.so echo_return',
+              'session required        pam_unix.so'
+            ]
+
           } else {
             $default_pam_auth_lines = [
               'auth        required      pam_env.so',
@@ -202,6 +250,13 @@ class pam (
               'auth        sufficient    pam_unix.so nullok try_first_pass',
               'auth        requisite     pam_succeed_if.so uid >= 500 quiet',
               'auth        required      pam_deny.so',
+            ]
+
+            $default_pam_password_auth_lines = [
+              'auth        required      pam_env.so',
+              'auth        sufficient    pam_unix.so nullok try_first_pass',
+              'auth        requisite     pam_succeed_if.so uid >= 500 quiet',
+              'auth        required      pam_deny.so'
             ]
 
             $default_pam_account_lines = [
@@ -223,6 +278,25 @@ class pam (
               'session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid',
               'session     required      pam_unix.so',
             ]
+            $default_pam_password_account_lines = [
+              'account     required      pam_unix.so',
+              'account     sufficient    pam_localuser.so',
+              'account     sufficient    pam_succeed_if.so uid < 500 quiet',
+              'account     required      pam_permit.so'
+            ]
+
+            $default_pam_password_password_lines = [
+              'password    requisite     pam_cracklib.so try_first_pass retry=3 type=',
+              'password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok',
+              'password    required      pam_deny.so'
+            ]
+
+            $default_pam_password_session_lines = [
+              'session     optional      pam_keyinit.so revoke',
+              'session     required      pam_limits.so',
+              'session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid',
+              'session     required      pam_unix.so'
+            ]
           }
         }
         '7': {
@@ -240,6 +314,14 @@ class pam (
                   'auth        sufficient    pam_unix.so nullok try_first_pass use_first_pass',
                   'auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success',
                   'auth        required      pam_deny.so',
+                ]
+                $default_pam_password_auth_lines = [
+                  'auth    required        pam_env.so',
+                  'auth    sufficient      pam_vas3.so create_homedir get_nonvas_pass',
+                  'auth    requisite       pam_vas3.so echo_return',
+                  'auth    sufficient      pam_unix.so nullok try_first_pass use_first_pass',
+                  'auth    requisite       pam_succeed_if.so uid >= 1000 quiet_success',
+                  'auth    required        pam_deny.so'
                 ]
               }
               default: {
@@ -273,6 +355,32 @@ class pam (
               'session     requisite     pam_vas3.so echo_return',
               'session     required      pam_unix.so',
             ]
+            $default_pam_password_account_lines = [
+              'account sufficient      pam_vas3.so',
+              'account requisite       pam_vas3.so echo_return',
+              'account required        pam_unix.so',
+              'account sufficient      pam_localuser.so',
+              'account sufficient      pam_succeed_if.so uid < 1000 quiet',
+              'account required        pam_permit.so'
+            ]
+
+            $default_pam_password_password_lines = [
+              'password        requisite       pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=',
+              'password        sufficient      pam_vas3.so',
+              'password        requisite       pam_vas3.so echo_return',
+              'password        sufficient      pam_unix.so md5 shadow nullok try_first_pass use_authtok',
+              'password        required        pam_deny.so'
+            ]
+
+            $default_pam_password_session_lines = [
+              'session optional        pam_keyinit.so revoke',
+              'session required        pam_limits.so',
+              '-session        optional        pam_systemd.so',
+              'session [success=1 default=ignore]      pam_succeed_if.so service in crond quiet use_uid',
+              'session required        pam_vas3.so create_homedir',
+              'session requisite       pam_vas3.so echo_return',
+              'session required        pam_unix.so'
+            ]
           } else {
             $default_pam_auth_lines = [
               'auth        required      pam_env.so',
@@ -280,6 +388,13 @@ class pam (
               'auth        sufficient    pam_unix.so nullok try_first_pass',
               'auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success',
               'auth        required      pam_deny.so',
+            ]
+
+            $default_pam_password_auth_lines = [
+              'auth        required      pam_env.so',
+              'auth        sufficient    pam_unix.so nullok try_first_pass',
+              'auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success',
+              'auth        required      pam_deny.so'
             ]
 
             $default_pam_account_lines = [
@@ -301,6 +416,25 @@ class pam (
               '-session    optional      pam_systemd.so',
               'session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid',
               'session     required      pam_unix.so',
+            ]
+            $default_pam_password_account_lines = [
+              'account     required      pam_unix.so',
+              'account     sufficient    pam_localuser.so',
+              'account     sufficient    pam_succeed_if.so uid < 1000 quiet',
+              'account     required      pam_permit.so'
+            ]
+
+            $default_pam_password_password_lines = [
+              'password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=',
+              'password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok',
+              'password    required      pam_deny.so'
+            ]
+            $default_pam_password_session_lines = [
+              'session     optional      pam_keyinit.so revoke',
+              'session     required      pam_limits.so',
+              '-session     optional      pam_systemd.so',
+              'session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid',
+              'session     required      pam_unix.so'
             ]
           }
         }
@@ -989,6 +1123,36 @@ class pam (
     $my_pam_session_lines = $pam_session_lines
   }
 
+if ( $::osfamily == 'RedHat' ) and ( $::operatingsystemmajrelease == '6' or $::operatingsystemmajrelease == '7' ) {
+  if $pam_password_auth_lines == undef {
+    $my_pam_password_auth_lines = $default_pam_password_auth_lines
+  } else {
+    $my_pam_password_auth_lines = $pam_password_auth_lines
+  }
+  validate_array($my_pam_password_auth_lines)
+
+  if $pam_password_account_lines == undef {
+    $my_pam_password_account_lines = $default_pam_password_account_lines
+  } else {
+    $my_pam_password_account_lines = $pam_password_account_lines
+  }
+  validate_array($my_pam_password_account_lines)
+
+  if $pam_password_password_lines == undef {
+    $my_pam_password_password_lines = $default_pam_password_password_lines
+  } else {
+    $my_pam_password_password_lines = $pam_password_password_lines
+  }
+  validate_array($my_pam_password_password_lines)
+
+  if $pam_password_session_lines == undef {
+    $my_pam_password_session_lines = $default_pam_password_session_lines
+  } else {
+    $my_pam_password_session_lines = $pam_password_session_lines
+  }
+  validate_array($my_pam_password_session_lines)
+}
+
   if $services != undef {
     create_resources('pam::service',$services)
   }
@@ -1001,6 +1165,9 @@ class pam (
     }
     create_resources('pam::limits::fragment',$limits_fragments_real)
   }
+
+  validate_absolute_path($password_auth_ac_file)
+  validate_absolute_path($password_auth_file)
 
   case $::osfamily {
     'RedHat', 'Suse', 'Debian': {
@@ -1032,7 +1199,6 @@ class pam (
 
       case $::osfamily {
         'RedHat': {
-
           file { 'pam_system_auth_ac':
             ensure  => file,
             path    => $system_auth_ac_file,
@@ -1052,6 +1218,26 @@ class pam (
             require => Package[$my_package_name],
           }
 
+          if $::operatingsystemmajrelease == '6' or $::operatingsystemmajrelease == '7' {
+            file { 'pam_password_auth_ac':
+              ensure  => file,
+              path    => $password_auth_ac_file,
+              content => template('pam/password-auth-ac.erb'),
+              owner   => 'root',
+              group   => 'root',
+              mode    => '0644',
+              require => Package[$my_package_name],
+            }
+
+            file { 'pam_password_auth':
+              ensure  => symlink,
+              path    => $password_auth_file,
+              target  => $password_auth_ac_file,
+              owner   => 'root',
+              group   => 'root',
+              require => Package[$my_package_name],
+            }
+          }
         }
         'Debian' : {
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -20,8 +20,8 @@ describe 'pam' do
         :releasetype        => 'operatingsystemmajrelease',
         :packages           => ['pam', ],
         :files              => [
-          { :prefix         => 'pam_system_',
-            :types          => ['auth', ],
+          { :prefix         => 'pam_',
+            :types          => ['system_auth', 'password_auth', ],
             :suffix         => '_ac',
             :symlink        => true,
           }, ],
@@ -32,8 +32,8 @@ describe 'pam' do
         :releasetype        => 'operatingsystemmajrelease',
         :packages           => ['pam', ],
         :files              => [
-          { :prefix         => 'pam_system_',
-            :types          => ['auth', ],
+          { :prefix         => 'pam_',
+            :types          => ['system_auth', ],
             :suffix         => '_ac',
             :symlink        => true,
           }, ],
@@ -362,6 +362,22 @@ describe 'pam' do
               end
             end
 
+            if v[:osfamily] == 'RedHat'
+              if (v[:release] == '6' or v[:release] == '7')
+                  it {
+                    should contain_file('pam_password_auth_ac').with({
+                      'ensure' => 'file',
+                      'path'   => '/etc/pam.d/password-auth-ac',
+                      'owner'  => 'root',
+                      'group'  => 'root',
+                      'mode'   => '0644',
+                    })
+                  }
+                  pam_password_auth_ac_fixture = File.read(fixtures("pam_password_auth_ac.#{check}.#{k}"))
+                  it { should contain_file('pam_password_auth_ac').with_content(pam_password_auth_ac_fixture) }
+              end
+            end
+
             if v[:osfamily] != 'Solaris'
               it {
                 should contain_file('pam_d_login').with({
@@ -445,6 +461,68 @@ describe 'pam' do
         end
       end
 
+      context "with password_auth_ac => path on osfamily #{v[:osfamily]} with #{v[:releasetype]} #{v[:release]}" do
+        let :facts do
+          { :osfamily => v[:osfamily],
+            :"#{v[:releasetype]}" => v[:release],
+            :lsbdistid => v[:lsbdistid],
+          }
+        end
+        if v[:osfamily] == 'RedHat' and v[:release] == '5'
+          it { should_not contain_file('password_auth_ac') }
+        end
+      end
+
+      context "with password_auth_ac_file => path on osfamily #{v[:osfamily]} with #{v[:releasetype]} #{v[:release]}" do
+        let :facts do
+          { :osfamily => v[:osfamily],
+            :"#{v[:releasetype]}" => v[:release],
+            :lsbdistid => v[:lsbdistid],
+          }
+        end
+        if v[:osfamily] == 'RedHat' and v[:release] == '5'
+          it { should_not contain_file('password_auth_ac_file') }
+        end
+      end
+
+      context "with password_auth_ac_file => invalid/path on osfamily #{v[:osfamily]} with #{v[:releasetype]} #{v[:release]}" do
+        let :facts do
+          { :osfamily => v[:osfamily],
+            :"#{v[:releasetype]}" => v[:release],
+            :lsbdistid => v[:lsbdistid],
+          }
+        end
+        let(:params) {{ :password_auth_ac_file => 'invalid/path' }}
+
+        if v[:osfamily] == 'RedHat' and (v[:release] == '6' or v[:release] == '7')
+          it 'should fail' do
+            expect {
+              should contain_class('pam')
+            }.to raise_error(Puppet::Error, /"invalid\/path" is not an absolute path/)
+          end
+
+        end
+      end
+
+      context "with password_auth_file => invalid/path on osfamily #{v[:osfamily]} with #{v[:releasetype]} #{v[:release]}" do
+        let :facts do
+          { :osfamily => v[:osfamily],
+            :"#{v[:releasetype]}" => v[:release],
+            :lsbdistid => v[:lsbdistid],
+          }
+        end
+        let(:params) {{ :password_auth_file => 'invalid/path' }}
+
+        if v[:osfamily] == 'RedHat' and (v[:release] == '6' or v[:release] == '7')
+          it 'should fail' do
+            expect {
+              should contain_class('pam')
+            }.to raise_error(Puppet::Error, /"invalid\/path" is not an absolute path/)
+          end
+
+        end
+      end
+
       context "with ensure_vas => present and vas_major_version => 3 on osfamily #{v[:osfamily]} with #{v[:releasetype]} #{v[:release]}" do
         let :facts do
           { :osfamily => v[:osfamily],
@@ -477,6 +555,28 @@ describe 'pam' do
           it { should contain_file('pam_system_auth_ac').with_content(/account[\s]+sufficient[\s]+pam_vas3.so/) }
           it { should contain_file('pam_system_auth_ac').with_content(/password[\s]+sufficient[\s]+pam_vas3.so/) }
           it { should contain_file('pam_system_auth_ac').with_content(/session[\s]+required[\s]+pam_vas3.so/) }
+        end
+
+        if v[:osfamily] == 'RedHat' and  v[:release] == '6'
+          it {
+            should contain_file('pam_password_auth_ac').with({
+              'ensure'  => 'file',
+              'path'    => '/etc/pam.d/password-auth-ac',
+              'owner'   => 'root',
+              'group'   => 'root',
+              'mode'    => '0644',
+            })
+          }
+
+          v[:packages].sort.each do |pkg|
+            it { should contain_file('pam_password_auth_ac').that_requires("Package[#{pkg}]") }
+          end
+
+          it { should contain_file('pam_password_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so create_homedir get_nonvas_pass/) }
+          it { should contain_file('pam_password_auth_ac').with_content(/account[\s]+sufficient[\s]+pam_vas3.so/) }
+          it { should contain_file('pam_password_auth_ac').with_content(/password[\s]+sufficient[\s]+pam_vas3.so/) }
+          it { should contain_file('pam_password_auth_ac').with_content(/session[\s]+required[\s]+pam_limits.so/) }
+          it { should_not contain_file('pam_password_auth_ac').with_content(/auth[\s]+sufficient[\s]+pam_vas3.so.*store_creds/) }
         end
 
         if v[:osfamily] == 'Debian' and v[:lsbdistid] == 'Ubuntu'
@@ -645,7 +745,7 @@ describe 'pam' do
         end
       end
 
-      context "with limits_fragments_hiera_merge prameter specified as an invalid string on #{v[:osfamily]} with #{v[:releasetype]} #{v[:release]}" do
+      context "with limits_fragments_hiera_merge parameter specified as an invalid string on #{v[:osfamily]} with #{v[:releasetype]} #{v[:release]}" do
         let :facts do
           { :osfamily => v[:osfamily],
             :"#{v[:releasetype]}" => v[:release],
@@ -661,7 +761,7 @@ describe 'pam' do
       end
 
       ['true',true,'false',false].each do |value|
-        context "with limits_fragments_hiera_merge prameter specified as a valid value: #{value} on #{v[:osfamily]} with #{v[:releasetype]} #{v[:release]}" do
+        context "with limits_fragments_hiera_merge parameter specified as a valid value: #{value} on #{v[:osfamily]} with #{v[:releasetype]} #{v[:release]}" do
           let :facts do
             { :osfamily => v[:osfamily],
               :"#{v[:releasetype]}" => v[:release],

--- a/spec/fixtures/pam_password_auth_ac.defaults.el6
+++ b/spec/fixtures/pam_password_auth_ac.defaults.el6
@@ -1,0 +1,24 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+# Auth
+auth        required      pam_env.so
+auth        sufficient    pam_unix.so nullok try_first_pass
+auth        requisite     pam_succeed_if.so uid >= 500 quiet
+auth        required      pam_deny.so
+
+# Account
+account     required      pam_unix.so
+account     sufficient    pam_localuser.so
+account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     required      pam_permit.so
+
+# Password
+password    requisite     pam_cracklib.so try_first_pass retry=3 type=
+password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok
+password    required      pam_deny.so
+
+# Session
+session     optional      pam_keyinit.so revoke
+session     required      pam_limits.so
+session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
+session     required      pam_unix.so

--- a/spec/fixtures/pam_password_auth_ac.defaults.el6
+++ b/spec/fixtures/pam_password_auth_ac.defaults.el6
@@ -1,5 +1,6 @@
 # This file is being maintained by Puppet.
 # DO NOT EDIT
+#
 # Auth
 auth        required      pam_env.so
 auth        sufficient    pam_unix.so nullok try_first_pass
@@ -14,7 +15,7 @@ account     required      pam_permit.so
 
 # Password
 password    requisite     pam_cracklib.so try_first_pass retry=3 type=
-password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok
+password    sufficient    pam_unix.so md5 shadow nullok try_first_pass use_authtok
 password    required      pam_deny.so
 
 # Session

--- a/spec/fixtures/pam_password_auth_ac.defaults.el7
+++ b/spec/fixtures/pam_password_auth_ac.defaults.el7
@@ -1,0 +1,25 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+# Auth
+auth        required      pam_env.so
+auth        sufficient    pam_unix.so nullok try_first_pass
+auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success
+auth        required      pam_deny.so
+
+# Account
+account     required      pam_unix.so
+account     sufficient    pam_localuser.so
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
+account     required      pam_permit.so
+
+# Password
+password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
+password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok
+password    required      pam_deny.so
+
+# Session
+session     optional      pam_keyinit.so revoke
+session     required      pam_limits.so
+-session     optional      pam_systemd.so
+session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
+session     required      pam_unix.so

--- a/spec/fixtures/pam_password_auth_ac.defaults.el7
+++ b/spec/fixtures/pam_password_auth_ac.defaults.el7
@@ -1,5 +1,6 @@
 # This file is being maintained by Puppet.
 # DO NOT EDIT
+#
 # Auth
 auth        required      pam_env.so
 auth        sufficient    pam_unix.so nullok try_first_pass
@@ -14,7 +15,7 @@ account     required      pam_permit.so
 
 # Password
 password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
-password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok
+password    sufficient    pam_unix.so md5 shadow nullok try_first_pass use_authtok
 password    required      pam_deny.so
 
 # Session

--- a/spec/fixtures/pam_password_auth_ac.vas.el6
+++ b/spec/fixtures/pam_password_auth_ac.vas.el6
@@ -1,0 +1,32 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+# Auth
+auth    required        pam_env.so
+auth    sufficient      pam_vas3.so create_homedir get_nonvas_pass
+auth    requisite       pam_vas3.so echo_return
+auth    sufficient      pam_unix.so nullok try_first_pass use_first_pass
+auth    requisite       pam_succeed_if.so uid >= 500 quiet
+auth    required        pam_deny.so
+
+# Account
+account sufficient      pam_vas3.so
+account requisite       pam_vas3.so echo_return
+account required        pam_unix.so
+account sufficient      pam_localuser.so
+account sufficient      pam_succeed_if.so uid < 500 quiet
+account required        pam_permit.so
+
+# Password
+password        sufficient      pam_vas3.so
+password        requisite       pam_vas3.so echo_return
+password        requisite       pam_cracklib.so try_first_pass retry=3 type=
+password        sufficient      pam_unix.so md5 shadow nullok try_first_pass use_authtok
+password        required        pam_deny.so
+
+# Session
+session optional        pam_keyinit.so revoke
+session required        pam_limits.so
+session [success=1 default=ignore]      pam_succeed_if.so service in crond quiet use_uid
+session required        pam_vas3.so create_homedir
+session requisite       pam_vas3.so echo_return
+session required        pam_unix.so

--- a/spec/fixtures/pam_password_auth_ac.vas.el6
+++ b/spec/fixtures/pam_password_auth_ac.vas.el6
@@ -1,5 +1,6 @@
 # This file is being maintained by Puppet.
 # DO NOT EDIT
+#
 # Auth
 auth    required        pam_env.so
 auth    sufficient      pam_vas3.so create_homedir get_nonvas_pass

--- a/spec/fixtures/pam_password_auth_ac.vas.el7
+++ b/spec/fixtures/pam_password_auth_ac.vas.el7
@@ -1,0 +1,33 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+# Auth
+auth    required        pam_env.so
+auth    sufficient      pam_vas3.so create_homedir get_nonvas_pass
+auth    requisite       pam_vas3.so echo_return
+auth    sufficient      pam_unix.so nullok try_first_pass use_first_pass
+auth    requisite       pam_succeed_if.so uid >= 1000 quiet_success
+auth    required        pam_deny.so
+
+# Account
+account sufficient      pam_vas3.so
+account requisite       pam_vas3.so echo_return
+account required        pam_unix.so
+account sufficient      pam_localuser.so
+account sufficient      pam_succeed_if.so uid < 1000 quiet
+account required        pam_permit.so
+
+# Password
+password        requisite       pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
+password        sufficient      pam_vas3.so
+password        requisite       pam_vas3.so echo_return
+password        sufficient      pam_unix.so md5 shadow nullok try_first_pass use_authtok
+password        required        pam_deny.so
+
+# Session
+session optional        pam_keyinit.so revoke
+session required        pam_limits.so
+-session        optional        pam_systemd.so
+session [success=1 default=ignore]      pam_succeed_if.so service in crond quiet use_uid
+session required        pam_vas3.so create_homedir
+session requisite       pam_vas3.so echo_return
+session required        pam_unix.so

--- a/spec/fixtures/pam_password_auth_ac.vas.el7
+++ b/spec/fixtures/pam_password_auth_ac.vas.el7
@@ -1,5 +1,6 @@
 # This file is being maintained by Puppet.
 # DO NOT EDIT
+#
 # Auth
 auth    required        pam_env.so
 auth    sufficient      pam_vas3.so create_homedir get_nonvas_pass

--- a/templates/password-auth-ac.erb
+++ b/templates/password-auth-ac.erb
@@ -1,0 +1,21 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+# Auth
+<% @my_pam_password_auth_lines.each do |auth_line| -%>
+<%= auth_line %>
+<% end -%>
+
+# Account
+<% @my_pam_password_account_lines.each do |account_line| -%>
+<%= account_line %>
+<% end -%>
+
+# Password
+<% @my_pam_password_password_lines.each do |password_line| -%>
+<%= password_line %>
+<% end -%>
+
+# Session
+<% @my_pam_password_session_lines.each do |session_line| -%>
+<%= session_line %>
+<% end -%>

--- a/templates/password-auth-ac.erb
+++ b/templates/password-auth-ac.erb
@@ -1,5 +1,6 @@
 # This file is being maintained by Puppet.
 # DO NOT EDIT
+#
 # Auth
 <% @my_pam_password_auth_lines.each do |auth_line| -%>
 <%= auth_line %>


### PR DESCRIPTION
Created another pull request EL 6 - Adding support for password-auth

Pam config for RHEL6 uses both system-auth and password-auth but the module only manages system-auth.

"The problem with /etc/pam.d/system-auth is that it contains modules that are not usable in remote configurations so remote services such as sshd, vsftpd now use /etc/pam.d/password-auth." https://access.redhat.com/site/solutions/45492.
