### PR TITLE
Don't configure pam if vas installation failed

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,5 +9,14 @@ fixtures:
     common:
       repo: 'git://github.com/ghoneycutt/puppet-module-common.git'
       ref: 'v1.0.2'
+    vas:
+      repo: 'git://github.com/Ericsson/puppet-module-vas.git'
+      ref: 'v0.10.0'
+    nisclient:
+      repo: 'git://github.com/Ericsson/puppet-module-nisclient.git'
+      ref: 'v1.0.0'
+    rpcbind:
+      repo: 'git://github.com/ghoneycutt/puppet-module-rpcbind.git'
+      ref: 'v1.4.0'
   symlinks:
     pam: "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ Control module to be used for pam_access.so for sshd. Valid values are 'required
 
 - *Default*: 'required'
 
+ensure_vas
+----------
+Configure pam to use VAS. If you want this functionality you will need to include Ericsson/vas >= v0.2.0. Valid values are 'present' and 'absent'.
+
+- *Default*: 'absent'
+
 limits_fragments
 ----------------
 Hash of fragments to pass to pam::limits::fragments

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1263,4 +1263,18 @@ class pam (
       fail("Pam is only supported on RedHat, SuSE, Debian and Solaris osfamilies. Your osfamily is identified as <${::osfamily}>.")
     }
   }
+
+  if $ensure_vas == 'present' and ($::osfamily == 'RedHat' or $::osfamily == 'Debian' or ($::osfamily == 'Suse' and $::lsbmajdistrelease != '9')) {
+    include vas
+    File <| title == 'pam_common_auth'                   |> { require => [ Package[$my_package_name], Exec[vasinst], ], }
+    File <| title == 'pam_common_auth_pc'                |> { require => [ Package[$my_package_name], Exec[vasinst], ], }
+    File <| title == 'pam_common_account'                |> { require => [ Package[$my_package_name], Exec[vasinst], ], }
+    File <| title == 'pam_common_account_pc'             |> { require => [ Package[$my_package_name], Exec[vasinst], ], }
+    File <| title == 'pam_common_password'               |> { require => [ Package[$my_package_name], Exec[vasinst], ], }
+    File <| title == 'pam_common_password_pc'            |> { require => [ Package[$my_package_name], Exec[vasinst], ], }
+    File <| title == 'pam_common_noninteractive_session' |> { require => [ Package[$my_package_name], Exec[vasinst], ], }
+    File <| title == 'pam_common_session'                |> { require => [ Package[$my_package_name], Exec[vasinst], ], }
+    File <| title == 'pam_common_session_pc'             |> { require => [ Package[$my_package_name], Exec[vasinst], ], }
+    File <| title == 'pam_system_auth_ac'                |> { require => [ Package[$my_package_name], Exec[vasinst], ], }
+  }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -6,6 +6,7 @@ describe 'pam' do
       { :osfamily           => 'RedHat',
         :release            => '5',
         :releasetype        => 'operatingsystemmajrelease',
+        :kernel             => 'Linux',
         :packages           => ['pam', 'util-linux', ],
         :files              => [
           { :prefix         => 'pam_system_',
@@ -18,6 +19,7 @@ describe 'pam' do
       { :osfamily           => 'RedHat',
         :release            => '6',
         :releasetype        => 'operatingsystemmajrelease',
+        :kernel             => 'Linux',
         :packages           => ['pam', ],
         :files              => [
           { :prefix         => 'pam_system_',
@@ -30,6 +32,7 @@ describe 'pam' do
       { :osfamily           => 'RedHat',
         :release            => '7',
         :releasetype        => 'operatingsystemmajrelease',
+        :kernel             => 'Linux',
         :packages           => ['pam', ],
         :files              => [
           { :prefix         => 'pam_system_',
@@ -42,6 +45,7 @@ describe 'pam' do
       { :osfamily           => 'Suse',
         :release            => '9',
         :releasetype        => 'lsbmajdistrelease',
+        :kernel             => 'Linux',
         :packages           => ['pam', 'pam-modules', ],
         :files              => [
           { :prefix         => 'pam_',
@@ -52,6 +56,7 @@ describe 'pam' do
       { :osfamily           => 'Suse',
         :release            => '10',
         :releasetype        => 'lsbmajdistrelease',
+        :kernel             => 'Linux',
         :packages           => ['pam', ],
         :files              => [
           { :prefix         => 'pam_common_',
@@ -62,6 +67,7 @@ describe 'pam' do
       { :osfamily           => 'Suse',
         :release            => '11',
         :releasetype        => 'lsbmajdistrelease',
+        :kernel             => 'Linux',
         :packages           => ['pam', ],
         :files              => [
           { :prefix         => 'pam_common_',
@@ -74,6 +80,7 @@ describe 'pam' do
       { :osfamily           => 'Suse',
         :release            => '12',
         :releasetype        => 'lsbmajdistrelease',
+        :kernel             => 'Linux',
         :packages           => ['pam', ],
         :files              => [
           { :prefix         => 'pam_common_',
@@ -86,6 +93,7 @@ describe 'pam' do
       { :osfamily           => 'Solaris',
         :release            => '5.9',
         :releasetype        => 'kernelrelease',
+        :kernel             => 'SunOS',
         :packages           => ['pam_package', ],
         :files              => [
           { :prefix         => 'pam_',
@@ -98,6 +106,7 @@ describe 'pam' do
       { :osfamily           => 'Solaris',
         :release            => '5.10',
         :releasetype        => 'kernelrelease',
+        :kernel             => 'SunOS',
         :packages           => ['pam_package', ],
         :files              => [
           { :prefix         => 'pam_',
@@ -110,6 +119,7 @@ describe 'pam' do
       { :osfamily           => 'Solaris',
         :release            => '5.11',
         :releasetype        => 'kernelrelease',
+        :kernel             => 'SunOS',
         :packages           => ['pam_package', ],
         :files              => [
           { :prefix         => 'pam_',
@@ -122,6 +132,7 @@ describe 'pam' do
         :lsbdistid          => 'Ubuntu',
         :release            => '12.04',
         :releasetype        => 'lsbdistrelease',
+        :kernel             => 'Linux',
         :packages           => [ 'libpam0g', ],
         :files              => [
           { :prefix         => 'pam_common_',
@@ -133,6 +144,7 @@ describe 'pam' do
         :lsbdistid          => 'Ubuntu',
         :release            => '14.04',
         :releasetype        => 'lsbdistrelease',
+        :kernel             => 'Linux',
         :packages           => [ 'libpam0g', ],
         :files              => [
           { :prefix         => 'pam_common_',
@@ -235,6 +247,36 @@ describe 'pam' do
     end
   end
 
+  describe 'includes' do
+    platforms.sort.each do |k,v|
+      context "with ensure_vas => present on #{v[:osfamily]} with #{v[:releasetype]} #{v[:release]}" do
+        if v[:osfamily] == 'RedHat' or v[:osfamily] == 'Debian' or (v[:osfamily] == 'Suse' and v[:release] != '9')
+          let :facts do
+            { :osfamily => v[:osfamily],
+              :"#{v[:releasetype]}" => v[:release],
+              :lsbdistid => v[:lsbdistid],
+              :kernel    => v[:kernel],
+            }
+          end
+          let (:params) { {:ensure_vas => 'present'} }
+
+          it { should contain_class('vas') }
+        else
+          let :facts do
+            { :osfamily => v[:osfamily],
+              :"#{v[:releasetype]}" => v[:release],
+              :lsbdistid => v[:lsbdistid],
+              :kernel    => v[:kernel],
+            }
+          end
+          let (:params) { {:ensure_vas => 'present'} }
+
+          it { should_not contain_class('vas') }
+        end
+      end
+    end
+  end
+
   describe 'config files' do
     platforms.sort.each do |k,v|
       context "with specifying services param on #{v[:osfamily]} with #{v[:releasetype]} #{v[:release]}" do
@@ -265,6 +307,7 @@ describe 'pam' do
             { :osfamily => v[:osfamily],
               :"#{v[:releasetype]}" => v[:release],
               :lsbdistid => v[:lsbdistid],
+              :kernel    => v[:kernel],
             }
           end
           if check == 'vas'
@@ -296,6 +339,12 @@ describe 'pam' do
               v[:packages].sort.each do |pkg|
                 if v[:osfamily] != 'Solaris' and (v[:osfamily] != 'Suse' and v[:release] != 9)
                   it { should contain_file(filename).that_requires("Package[#{pkg}]") }
+                end
+              end
+
+              if check == 'vas'
+                if v[:osfamily] == 'RedHat' or v[:osfamily] == 'Debian' or (v[:osfamily] == 'Suse' and v[:release] != '9')
+                  it { should contain_file(filename).that_requires('Exec[vasinst]') }
                 end
               end
 
@@ -408,6 +457,7 @@ describe 'pam' do
           { :osfamily => v[:osfamily],
             :"#{v[:releasetype]}" => v[:release],
             :lsbdistid => v[:lsbdistid],
+            :kernel => v[:kernel],
           }
         end
         let :params do
@@ -435,6 +485,8 @@ describe 'pam' do
           it { should contain_file('pam_system_auth_ac').with_content(/account[\s]+sufficient[\s]+pam_vas3.so/) }
           it { should contain_file('pam_system_auth_ac').with_content(/password[\s]+sufficient[\s]+pam_vas3.so/) }
           it { should contain_file('pam_system_auth_ac').with_content(/session[\s]+required[\s]+pam_vas3.so/) }
+
+          it { should contain_file('pam_system_auth_ac').that_requires('Exec[vasinst]') }
         end
 
         if v[:osfamily] == 'Debian'
@@ -457,6 +509,8 @@ describe 'pam' do
             v[:packages].sort.each do |pkg|
               it { should contain_file("pam_common_#{type}").that_requires("Package[#{pkg}]") }
             end
+
+            it { should contain_file("pam_common_#{type}").that_requires('Exec[vasinst]') }
           end
 
           it {
@@ -474,6 +528,8 @@ describe 'pam' do
           v[:packages].sort.each do |pkg|
             it { should contain_file("pam_common_noninteractive_session").that_requires("Package[#{pkg}]") }
           end
+
+          it { should contain_file("pam_common_noninteractive_session").that_requires('Exec[vasinst]') }
         end
       end
     end


### PR DESCRIPTION
Configuring pam to use vas when the vas installation failed will cause
the machine to enter a broken state where logins are not possible.