### PR TITLE
Add support for OpenSuSE 13.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This module has been tested to work on the following systems using Puppet v3 wit
  * Suse 10
  * Suse 11
  * Suse 12
+ * OpenSuSE 13.1
  * Ubuntu 12.04 LTS
  * Ubuntu 14.04 LTS
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -501,8 +501,42 @@ class pam (
             ]
           }
         }
+        '13': {
+          $default_pam_d_login_template = 'pam/login.suse13.erb'
+          $default_pam_d_sshd_template  = 'pam/sshd.suse13.erb'
+          $default_package_name         = 'pam'
+
+          if $ensure_vas == 'present' {
+            fail("Pam: vas is not supported on ${::osfamily} ${::lsbmajdistrelease}")
+          } else {
+            $default_pam_auth_lines = [
+              'auth  required  pam_env.so',
+              'auth  optional  pam_gnome_keyring.so',
+              'auth  required  pam_unix.so try_first_pass',
+            ]
+
+            $default_pam_account_lines = [
+              'account  required  pam_unix.so try_first_pass',
+            ]
+
+            $default_pam_password_lines = [
+              'password  requisite  pam_cracklib.so',
+              'password  optional   pam_gnome_keyring.so use_authtok',
+              'password  required   pam_unix.so use_authtok nullok shadow try_first_pass',
+            ]
+
+            $default_pam_session_lines = [
+              'session  required pam_limits.so',
+              'session  required pam_unix.so try_first_pass',
+              'session  optional pam_umask.so',
+              'session  optional pam_systemd.so',
+              'session  optional pam_gnome_keyring.so auto_start only_if=gdm,gdm-password,lxdm,lightdm',
+              'session  optional pam_env.so'
+            ]
+          }
+        }
         default: {
-          fail("Pam is only supported on Suse 10, 11, and 12. Your lsbmajdistrelease is identified as <${::lsbmajdistrelease}>.")
+          fail("Pam is only supported on Suse 9, 10, 11, 12 and 13. Your lsbmajdistrelease is identified as <${::lsbmajdistrelease}>.")
         }
       }
     }
@@ -1156,7 +1190,7 @@ class pam (
                 require => Package[$my_package_name],
               }
             }
-            '12': {
+            '12','13': {
 
               file { 'pam_common_auth_pc':
                 ensure  => file,
@@ -1235,7 +1269,7 @@ class pam (
               }
             }
             default : {
-              fail("Pam is only supported on Suse 9, 10, 11 and 12. Your lsbmajdistrelease is identified as <${::lsbmajdistrelease}>.")
+              fail("Pam is only supported on Suse 9, 10, 11, 12 and 13. Your lsbmajdistrelease is identified as <${::lsbmajdistrelease}>.")
             }
           }
         }

--- a/metadata.json
+++ b/metadata.json
@@ -83,6 +83,12 @@
       ]
     },
     {
+      "operatingsystem": "OpenSuSE",
+      "operatingsystemrelease": [
+        "13.1"
+      ]
+    },
+    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "12.04",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -82,6 +82,18 @@ describe 'pam' do
             :symlink        => true,
           }, ],
       },
+    'suse13'                =>
+      { :osfamily           => 'Suse',
+        :release            => '13',
+        :releasetype        => 'lsbmajdistrelease',
+        :packages           => ['pam', ],
+        :files              => [
+          { :prefix         => 'pam_common_',
+            :types          => ['auth', 'account', 'password', 'session', ],
+            :suffix         => '_pc',
+            :symlink        => true,
+          }, ],
+      },
     'solaris9'              =>
       { :osfamily           => 'Solaris',
         :release            => '5.9',
@@ -269,6 +281,15 @@ describe 'pam' do
           end
           if check == 'vas'
             let(:params) { {:ensure_vas => 'present'} }
+          end
+
+          if check == 'vas' and v[:osfamily] == 'Suse' and v[:release] == '13'
+            it 'should fail' do
+              expect {
+                should contain_class('pam')
+              }.to raise_error(Puppet::Error,/Pam: vas is not supported on #{v[:osfamily]} #{v[:release]}/)
+            end
+            next
           end
 
           v[:files].each do |file|

--- a/spec/fixtures/pam_common_account_pc.defaults.suse13
+++ b/spec/fixtures/pam_common_account_pc.defaults.suse13
@@ -1,0 +1,3 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+account  required  pam_unix.so try_first_pass

--- a/spec/fixtures/pam_common_auth_pc.defaults.suse13
+++ b/spec/fixtures/pam_common_auth_pc.defaults.suse13
@@ -1,0 +1,5 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+auth  required  pam_env.so
+auth  optional  pam_gnome_keyring.so
+auth  required  pam_unix.so try_first_pass

--- a/spec/fixtures/pam_common_password_pc.defaults.suse13
+++ b/spec/fixtures/pam_common_password_pc.defaults.suse13
@@ -1,0 +1,5 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+password  requisite  pam_cracklib.so
+password  optional   pam_gnome_keyring.so use_authtok
+password  required   pam_unix.so use_authtok nullok shadow try_first_pass

--- a/spec/fixtures/pam_common_session_pc.defaults.suse13
+++ b/spec/fixtures/pam_common_session_pc.defaults.suse13
@@ -1,0 +1,8 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+session  required pam_limits.so
+session  required pam_unix.so try_first_pass
+session  optional pam_umask.so
+session  optional pam_systemd.so
+session  optional pam_gnome_keyring.so auto_start only_if=gdm,gdm-password,lxdm,lightdm
+session  optional pam_env.so

--- a/spec/fixtures/pam_d_login.defaults.suse13
+++ b/spec/fixtures/pam_d_login.defaults.suse13
@@ -1,0 +1,9 @@
+#%PAM-1.0
+auth     requisite      pam_nologin.so
+auth     [user_unknown=ignore success=ok ignore=ignore auth_err=die default=bad]        pam_securetty.so
+auth     include        common-auth
+account  include        common-account
+password include        common-password
+session  required       pam_loginuid.so
+session  include        common-session
+session  optional       pam_mail.so standard

--- a/spec/fixtures/pam_d_sshd.defaults.suse13
+++ b/spec/fixtures/pam_d_sshd.defaults.suse13
@@ -1,0 +1,9 @@
+#%PAM-1.0
+auth     requisite      pam_nologin.so
+auth     include        common-auth
+account  requisite      pam_nologin.so
+account  include        common-account
+password include        common-password
+session  required       pam_loginuid.so
+session  include        common-session
+session  optional       pam_lastlog.so   silent noupdate showfailed

--- a/templates/login.suse13.erb
+++ b/templates/login.suse13.erb
@@ -1,0 +1,9 @@
+#%PAM-1.0
+auth     requisite      pam_nologin.so
+auth     [user_unknown=ignore success=ok ignore=ignore auth_err=die default=bad]        pam_securetty.so
+auth     include        common-auth
+account  include        common-account
+password include        common-password
+session  required       pam_loginuid.so
+session  include        common-session
+session  optional       pam_mail.so standard

--- a/templates/sshd.suse13.erb
+++ b/templates/sshd.suse13.erb
@@ -1,0 +1,9 @@
+#%PAM-1.0
+auth     requisite      pam_nologin.so
+auth     include        common-auth
+account  requisite      pam_nologin.so
+account  include        common-account
+password include        common-password
+session  required       pam_loginuid.so
+session  include        common-session
+session  optional       pam_lastlog.so   silent noupdate showfailed


### PR DESCRIPTION
Updated README.md, metadata.json, and added spec tests.

The default values are taken from a fresh installed box, with local authentication.

I don't really know what this 'vas' is good for, and I could not test it, so the module
fails when trying to enable vas on OpenSuse 13. Getting the specs right for that
was a bit tricky, but I check if it's suse 13, and then jump to the next iteration of the
specs loop.

let me know if there is something that needs changes/enhancements....

cheers,
