### PR TITLE
Suse12: Add systemd and pam_envd to common session

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -477,7 +477,9 @@ class pam (
               'session  required   pam_vas3.so create_homedir',
               'session  requisite  pam_vas3.so echo_return',
               'session  required   pam_unix2.so',
-              'session  optional   pam_umask.so'
+              'session  optional   pam_umask.so',
+              'session  optional   pam_systemd.so',
+              'session  optional   pam_env.so',
             ]
           } else {
             $default_pam_auth_lines = [
@@ -497,7 +499,9 @@ class pam (
             $default_pam_session_lines = [
               'session  required  pam_limits.so',
               'session  required  pam_unix2.so',
-              'session  optional  pam_umask.so'
+              'session  optional  pam_umask.so',
+              'session  optional  pam_systemd.so',
+              'session  optional  pam_env.so',
             ]
           }
         }

--- a/spec/fixtures/pam_common_session_pc.defaults.suse12
+++ b/spec/fixtures/pam_common_session_pc.defaults.suse12
@@ -3,3 +3,5 @@
 session  required  pam_limits.so
 session  required  pam_unix2.so
 session  optional  pam_umask.so
+session  optional  pam_systemd.so
+session  optional  pam_env.so

--- a/spec/fixtures/pam_common_session_pc.vas.suse12
+++ b/spec/fixtures/pam_common_session_pc.vas.suse12
@@ -5,3 +5,5 @@ session  required   pam_vas3.so create_homedir
 session  requisite  pam_vas3.so echo_return
 session  required   pam_unix2.so
 session  optional   pam_umask.so
+session  optional   pam_systemd.so
+session  optional   pam_env.so


### PR DESCRIPTION
With the current PAM configuration on Suse 12 it's not possible to log in locally through the login manager (using X) because it uses systemd. systemd is however not included in PAM session file.
pam_envd also added.

Original file:
`````
...
session	required	pam_limits.so	
session	required	pam_unix.so	try_first_pass 
session	optional	pam_umask.so	
session	optional	pam_systemd.so
session	optional	pam_gnome_keyring.so	auto_start only_if=gdm,gdm-password,lxdm,lightdm 
session	optional	pam_env.so	
`````