### PR TITLE
Add the ability to use System Security Services Daemon (SSSD) for authentication

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,7 @@ class pam (
   $login_pam_access                    = 'required',
   $sshd_pam_access                     = 'required',
   $ensure_vas                          = 'absent',
+  $ensure_sss                          = 'absent',
   $package_name                        = undef,
   $pam_conf_file                       = '/etc/pam.conf',
   $services                            = undef,
@@ -274,34 +275,68 @@ class pam (
               'session     required      pam_unix.so'
             ]
           } else {
-            $default_pam_auth_lines = [
-              'auth        required      pam_env.so',
-              'auth        sufficient    pam_fprintd.so',
-              'auth        sufficient    pam_unix.so nullok try_first_pass',
-              'auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success',
-              'auth        required      pam_deny.so'
-            ]
+            if $ensure_sss == 'present' {
+              $default_pam_auth_lines = [
+                'auth        required      pam_env.so',
+                'auth        sufficient    pam_unix.so nullok try_first_pass',
+                'auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success',
+                'auth        sufficient    pam_sss.so use_first_pass',
+                'auth        required      pam_deny.so'
+              ]
 
-            $default_pam_account_lines = [
-              'account     required      pam_unix.so',
-              'account     sufficient    pam_localuser.so',
-              'account     sufficient    pam_succeed_if.so uid < 1000 quiet',
-              'account     required      pam_permit.so'
-            ]
+              $default_pam_account_lines = [
+                'account     required      pam_unix.so',
+                'account     sufficient    pam_localuser.so',
+                'account     sufficient    pam_succeed_if.so uid < 1000 quiet',
+                'account     [default=bad success=ok user_unknown=ignore] pam_sss.so',
+                'account     required      pam_permit.so'
+              ]
 
-            $default_pam_password_lines = [
-              'password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=',
-              'password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok',
-              'password    required      pam_deny.so'
-            ]
+              $default_pam_password_lines = [
+                'password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=',
+                'password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok',
+                'password    sufficient    pam_sss.so use_authtok',
+                'password    required      pam_deny.so'
+              ]
 
-            $default_pam_session_lines = [
-              'session     optional      pam_keyinit.so revoke',
-              'session     required      pam_limits.so',
-              '-session    optional      pam_systemd.so',
-              'session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid',
-              'session     required      pam_unix.so'
-            ]
+              $default_pam_session_lines = [
+                'session     optional      pam_keyinit.so revoke',
+                'session     required      pam_limits.so',
+                '-session    optional      pam_systemd.so',
+                'session     optional      pam_oddjob_mkhomedir.so umask=0077',
+                'session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid',
+                'session     required      pam_unix.so',
+                'session     optional      pam_sss.so'
+              ]
+            } else {
+              $default_pam_auth_lines = [
+                'auth        required      pam_env.so',
+                'auth        sufficient    pam_unix.so nullok try_first_pass',
+                'auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success',
+                'auth        required      pam_deny.so'
+              ]
+
+              $default_pam_account_lines = [
+                'account     required      pam_unix.so',
+                'account     sufficient    pam_localuser.so',
+                'account     sufficient    pam_succeed_if.so uid < 1000 quiet',
+                'account     required      pam_permit.so'
+              ]
+
+              $default_pam_password_lines = [
+                'password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=',
+                'password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok',
+                'password    required      pam_deny.so'
+              ]
+
+              $default_pam_session_lines = [
+                'session     optional      pam_keyinit.so revoke',
+                'session     required      pam_limits.so',
+                '-session    optional      pam_systemd.so',
+                'session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid',
+                'session     required      pam_unix.so'
+              ]
+            }
           }
         }
         default: {

--- a/templates/access.conf.erb
+++ b/templates/access.conf.erb
@@ -16,10 +16,14 @@ entries = scope.lookupvar('pam::allowed_users')
 + : <%= key %> : ALL
 <% end -%>
 <% elsif entries.is_a? String -%>
+<% if entries != 'ALL' -%>
 + : <%= entries %> : ALL
-<% else -%>
-+ : root : ALL
-<% end -%>
-
 # default deny
 - : ALL : ALL
+<% else -%>
++ : root : ALL
+# default deny
+- : ALL : ALL
+<% end -%>
+<% end -%>
+


### PR DESCRIPTION
When using FreeIPA, (and LDAP, too), SSS provides the functionality for sudo via pam. This patch enables a default for a flag 'enable_sss'. Additiionally, I removed 'auth sufficient pam_fprintd.so' as this is not standard on server systems. Creating a config set of lines would be more appropriate.

access.conf should use the defaults if nothing is set. However, because of the way it is coded, a hiera value "pam::allowed_users: 'ALL'" is needed to adjust this to ensure default file would be in place. If no hiera exists, the original behavior of root only being allowed will occur.