### PR TITLE
Set pam_access on EL7 for sshd and login - treat the same as EL5 and EL6

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -435,7 +435,7 @@ describe 'pam' do
         end
         let(:params) {{ :login_pam_access => 'sufficient' }}
 
-        if (v[:osfamily] == 'RedHat' and (v[:release] == '5' or v[:release] == '6')) or (v[:osfamily] == 'Suse' and v[:release] == '11')
+        if (v[:osfamily] == 'RedHat') or (v[:osfamily] == 'Suse' and v[:release] == '11')
           it { should contain_file('pam_d_login').with_content(/account[\s]+sufficient[\s]+pam_access.so/) }
         end
       end
@@ -462,7 +462,7 @@ describe 'pam' do
         end
         let(:params) {{ :sshd_pam_access => 'sufficient' }}
 
-        if (v[:osfamily] == 'RedHat' and (v[:release] == '5' or v[:release] == '6')) or (v[:osfamily] == 'Suse' and v[:release] == '11')
+        if (v[:osfamily] == 'RedHat') or (v[:osfamily] == 'Suse' and v[:release] == '11')
           it { should contain_file('pam_d_sshd').with_content(/^account[\s]+sufficient[\s]+pam_access.so$/) }
         end
       end

--- a/spec/fixtures/pam_d_login.defaults.el7
+++ b/spec/fixtures/pam_d_login.defaults.el7
@@ -4,6 +4,7 @@ auth       substack     system-auth
 auth       include      postlogin
 account    required     pam_nologin.so
 account    include      system-auth
+account    required     pam_access.so
 password   include      system-auth
 # pam_selinux.so close should be the first session rule
 session    required     pam_selinux.so close

--- a/spec/fixtures/pam_d_sshd.defaults.el7
+++ b/spec/fixtures/pam_d_sshd.defaults.el7
@@ -2,6 +2,7 @@
 auth       required     pam_sepermit.so
 auth       substack     password-auth
 auth       include      postlogin
+account    required     pam_access.so
 account    required     pam_nologin.so
 account    include      password-auth
 password   include      password-auth

--- a/templates/login.el7.erb
+++ b/templates/login.el7.erb
@@ -4,6 +4,9 @@ auth       substack     system-auth
 auth       include      postlogin
 account    required     pam_nologin.so
 account    include      system-auth
+<% if @login_pam_access != 'absent' -%>
+account    <%= @login_pam_access %>     pam_access.so
+<% end -%>
 password   include      system-auth
 # pam_selinux.so close should be the first session rule
 session    required     pam_selinux.so close

--- a/templates/sshd.el7.erb
+++ b/templates/sshd.el7.erb
@@ -2,6 +2,9 @@
 auth       required     pam_sepermit.so
 auth       substack     password-auth
 auth       include      postlogin
+<% if @sshd_pam_access != 'absent' -%>
+account    <%= @sshd_pam_access %>     pam_access.so
+<% end -%>
 account    required     pam_nologin.so
 account    include      password-auth
 password   include      password-auth


### PR DESCRIPTION
This is a change I've made in my fork (ref #76) for a while and have branched it off for acceptance.  This basically treats EL7 just like EL5 and EL6 in terms of the inclusion of pam_access.
