### PR TITLE
Explicitly Denied Users in access.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ EL no longer requires the `redhat-lsb` package.
 
 allowed_users
 -------------
-Array or Hash of strings and/or arrays to configure users and origins in access.conf. The default allows the root user/group from origin 'ALL'.
+Array or Hash of strings and/or arrays to configure allowed users and origins in access.conf. The default allows the root user/group from origin 'ALL'.
 
 - *Default*: 'root'
 
@@ -86,6 +86,12 @@ This would create /etc/security/access.conf with the following content.
 + : username1 : cron tty0
 + : username2 : tty1
 </pre>
+
+denied_users
+-------------
+The same syntax as allowed_users, above. Any users added to this list will be denied access regardless of if they are in allowed_users. The default denies no additional users.  
+
+- *Default*: undef
 
 login_pam_access
 ----------------

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This would create /etc/security/access.conf with the following content.
 
 denied_users
 -------------
-The same syntax as allowed_users, above. Any users added to this list will be denied access regardless of if they are in allowed_users. The default denies no additional users.  
+The same syntax as allowed_users, above. Any users and origins added to this list will be denied access regardless of if they are in allowed_users. The default denies no additional users or origins.
 
 - *Default*: undef
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,7 @@
 #
 class pam (
   $allowed_users                       = 'root',
+  $denied_users                        = undef,
   $login_pam_access                    = 'required',
   $sshd_pam_access                     = 'required',
   $ensure_vas                          = 'absent',

--- a/spec/classes/accesslogin_spec.rb
+++ b/spec/classes/accesslogin_spec.rb
@@ -28,6 +28,8 @@ describe 'pam::accesslogin' do
 # DO NOT EDIT
 #
 
+# deny any users listed here
+
 # allow only the groups listed
 + : root : ALL
 
@@ -37,7 +39,7 @@ describe 'pam::accesslogin' do
       }
     end
 
-    context 'with multiple users on supported platform expressed as an array' do
+    context 'with multiple allowed users on supported platform expressed as an array' do
       let(:facts) do
         {
           :osfamily                   => 'RedHat',
@@ -67,6 +69,8 @@ describe 'pam::accesslogin' do
 # DO NOT EDIT
 #
 
+# deny any users listed here
+
 # allow only the groups listed
 + : foo : ALL
 + : bar : ALL
@@ -77,7 +81,95 @@ describe 'pam::accesslogin' do
       }
     end
 
-    context 'with hash entry containing string values' do
+    context 'with multiple denied users on supported platform expressed as an array' do
+      let(:facts) do
+        {
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
+        }
+      end
+      let(:pre_condition) do
+          'class {"pam": denied_users => ["foo","bar"] }'
+      end
+
+      it { should contain_class('pam') }
+
+      it {
+        should contain_file('access_conf').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/security/access.conf',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => [ 'Package[pam]', 'Package[util-linux]' ],
+        })
+      }
+
+      it {
+        should contain_file('access_conf').with_content(
+%{# This file is being maintained by Puppet.
+# DO NOT EDIT
+#
+
+# deny any users listed here
+- : foo : ALL
+- : bar : ALL
+
+# allow only the groups listed
++ : root : ALL
+
+# default deny
+- : ALL : ALL
+})
+      }
+    end
+
+context 'with multiple allowed and denied users on supported platform expressed as an array' do
+      let(:facts) do
+        {
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
+        }
+      end
+      let(:pre_condition) do
+          'class {"pam": allowed_users => ["foo","bar"], 
+	                 denied_users => ["baz","qux"] }'
+      end
+
+      it { should contain_class('pam') }
+
+      it {
+        should contain_file('access_conf').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/security/access.conf',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => [ 'Package[pam]', 'Package[util-linux]' ],
+        })
+      }
+
+      it {
+        should contain_file('access_conf').with_content(
+%{# This file is being maintained by Puppet.
+# DO NOT EDIT
+#
+
+# deny any users listed here
+- : baz : ALL
+- : qux : ALL
+
+# allow only the groups listed
++ : foo : ALL
++ : bar : ALL
+
+# default deny
+- : ALL : ALL
+})
+      }
+    end
+
+    context 'with hash entry for allowed users containing string values for origin' do
       let(:facts) do
         {
           :osfamily                   => 'RedHat',
@@ -91,7 +183,39 @@ describe 'pam::accesslogin' do
       it { should contain_file('access_conf').with_content(/^\+ : username2 : tty0$/)}
     end
 
-    context 'with hash entry containing array of values' do
+    context 'with hash entry for denied users containing string values for origin' do
+      let(:facts) do
+        {
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
+        }
+      end
+      let(:pre_condition) do
+          'class {"pam": denied_users => {"username1" => "cron", "username2" => "tty0"} }'
+      end
+      it { should contain_file('access_conf').with_content(/^\- : username1 : cron$/)}
+      it { should contain_file('access_conf').with_content(/^\- : username2 : tty0$/)}
+      it { should contain_file('access_conf').with_content(/^\+ : root : ALL$/)}
+    end
+
+    context 'with hash entry for both allowed and denied users containing string values for origin' do
+      let(:facts) do
+        {
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
+        }
+      end
+      let(:pre_condition) do
+          'class {"pam": allowed_users => {"username1" => "cron", "username2" => "tty0"}, 
+		         denied_users => {"username3" => "tty1", "username4" => "tty2"} }'
+      end
+      it { should contain_file('access_conf').with_content(/^\- : username3 : tty1$/)}
+      it { should contain_file('access_conf').with_content(/^\- : username4 : tty2$/)}
+      it { should contain_file('access_conf').with_content(/^\+ : username1 : cron$/)}
+      it { should contain_file('access_conf').with_content(/^\+ : username2 : tty0$/)}
+    end
+
+    context 'with hash entry for allowed users containing array of values for origin' do
       let(:facts) do
         {
           :osfamily                   => 'RedHat',
@@ -104,7 +228,37 @@ describe 'pam::accesslogin' do
       it { should contain_file('access_conf').with_content(/^\+ : username : cron tty0$/)}
     end
 
-    context 'with hash entry containing no value should default to "ALL"' do
+    context 'with hash entry for denied users containing array of values for origin' do
+      let(:facts) do
+        {
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
+        }
+      end
+      let(:pre_condition) do
+          'class {"pam": denied_users => {"username" => ["cron", "tty0"]} }'
+      end
+      it { should contain_file('access_conf').with_content(/^\- : username : cron tty0$/)}
+      it { should contain_file('access_conf').with_content(/^\+ : root : ALL$/)}
+    end
+
+    context 'with hash entry for both allowed and denied users containing array of values for origin' do
+      let(:facts) do
+        {
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
+        }
+      end
+      let(:pre_condition) do
+          'class {"pam": allowed_users => {"username1" => ["cron", "tty0"]},
+                         denied_users => {"username2" => ["tty1", "tty2"]} }'
+
+      end
+      it { should contain_file('access_conf').with_content(/^\- : username2 : tty1 tty2$/)}
+      it { should contain_file('access_conf').with_content(/^\+ : username1 : cron tty0$/)}
+    end
+
+    context 'with hash entry for allowed users containing no value for origin should default to "ALL"' do
       let(:facts) do
         {
           :osfamily                   => 'RedHat',
@@ -117,7 +271,36 @@ describe 'pam::accesslogin' do
       it { should contain_file('access_conf').with_content(/^\+ : username : ALL$/)}
     end
 
-    context 'with hash entries containing string, array and empty hash' do
+    context 'with hash entry for denied users containing no value for origin should default to "ALL"' do
+      let(:facts) do
+        {
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
+        }
+      end
+      let(:pre_condition) do
+          'class {"pam": denied_users => {"username" => {} }}'
+      end
+      it { should contain_file('access_conf').with_content(/^\- : username : ALL$/)}
+      it { should contain_file('access_conf').with_content(/^\+ : root : ALL$/)}
+    end
+
+    context 'with hash entry for both allowed and denied users containing no value for origin should default to "ALL"' do
+      let(:facts) do
+        {
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
+        }
+      end
+      let(:pre_condition) do
+          'class {"pam": allowed_users => {"username1" => {} },
+                         denied_users => {"username2" => {} } }'
+      end
+      it { should contain_file('access_conf').with_content(/^\- : username2 : ALL$/)}
+      it { should contain_file('access_conf').with_content(/^\+ : username1 : ALL$/)}
+    end
+
+    context 'with hash entries for allowed users containing string, array and empty hash' do
       let(:facts) do
         {
           :osfamily                   => 'RedHat',
@@ -127,6 +310,47 @@ describe 'pam::accesslogin' do
       let(:pre_condition) do
           'class {"pam": allowed_users => {"username" => "tty5", "username1" => ["cron", "tty0"], "username2" => "cron", "username3" => "tty0", "username4" => {}}}'
       end
+      it { should contain_file('access_conf').with_content(/^\+ : username : tty5$/)}
+      it { should contain_file('access_conf').with_content(/^\+ : username1 : cron tty0$/)}
+      it { should contain_file('access_conf').with_content(/^\+ : username2 : cron$/)}
+      it { should contain_file('access_conf').with_content(/^\+ : username3 : tty0$/)}
+      it { should contain_file('access_conf').with_content(/^\+ : username4 : ALL$/)}
+    end
+
+    context 'with hash entries for denied users containing string, array and empty hash' do
+      let(:facts) do
+        {
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
+        }
+      end
+      let(:pre_condition) do
+          'class {"pam": denied_users => {"username" => "tty5", "username1" => ["cron", "tty0"], "username2" => "cron", "username3" => "tty0", "username4" => {}}}'
+      end
+      it { should contain_file('access_conf').with_content(/^\- : username : tty5$/)}
+      it { should contain_file('access_conf').with_content(/^\- : username1 : cron tty0$/)}
+      it { should contain_file('access_conf').with_content(/^\- : username2 : cron$/)}
+      it { should contain_file('access_conf').with_content(/^\- : username3 : tty0$/)}
+      it { should contain_file('access_conf').with_content(/^\- : username4 : ALL$/)}
+      it { should contain_file('access_conf').with_content(/^\+ : root : ALL$/)}
+    end
+
+    context 'with hash entries for both allowed and denied users containing string, array and empty hash' do
+      let(:facts) do
+        {
+          :osfamily                   => 'RedHat',
+          :operatingsystemmajrelease  => '5',
+        }
+      end
+      let(:pre_condition) do
+          'class {"pam": allowed_users => {"username" => "tty5", "username1" => ["cron", "tty0"], "username2" => "cron", "username3" => "tty0", "username4" => {}},
+	                 denied_users => {"username5" => "tty5", "username6" => ["cron", "tty0"], "username7" => "cron", "username8" => "tty0", "username9" => {}}}'
+      end
+      it { should contain_file('access_conf').with_content(/^\- : username5 : tty5$/)}
+      it { should contain_file('access_conf').with_content(/^\- : username6 : cron tty0$/)}
+      it { should contain_file('access_conf').with_content(/^\- : username7 : cron$/)}
+      it { should contain_file('access_conf').with_content(/^\- : username8 : tty0$/)}
+      it { should contain_file('access_conf').with_content(/^\- : username9 : ALL$/)}
       it { should contain_file('access_conf').with_content(/^\+ : username : tty5$/)}
       it { should contain_file('access_conf').with_content(/^\+ : username1 : cron tty0$/)}
       it { should contain_file('access_conf').with_content(/^\+ : username2 : cron$/)}

--- a/spec/classes/accesslogin_spec.rb
+++ b/spec/classes/accesslogin_spec.rb
@@ -28,9 +28,9 @@ describe 'pam::accesslogin' do
 # DO NOT EDIT
 #
 
-# deny any users listed here
+# deny any users or groups listed
 
-# allow only the groups listed
+# allow only the users or groups listed
 + : root : ALL
 
 # default deny
@@ -69,9 +69,9 @@ describe 'pam::accesslogin' do
 # DO NOT EDIT
 #
 
-# deny any users listed here
+# deny any users or groups listed
 
-# allow only the groups listed
+# allow only the users or groups listed
 + : foo : ALL
 + : bar : ALL
 
@@ -111,11 +111,11 @@ describe 'pam::accesslogin' do
 # DO NOT EDIT
 #
 
-# deny any users listed here
+# deny any users or groups listed
 - : foo : ALL
 - : bar : ALL
 
-# allow only the groups listed
+# allow only the users or groups listed
 + : root : ALL
 
 # default deny
@@ -155,11 +155,11 @@ context 'with multiple allowed and denied users on supported platform expressed 
 # DO NOT EDIT
 #
 
-# deny any users listed here
+# deny any users or groups listed
 - : baz : ALL
 - : qux : ALL
 
-# allow only the groups listed
+# allow only the users or groups listed
 + : foo : ALL
 + : bar : ALL
 

--- a/templates/access.conf.erb
+++ b/templates/access.conf.erb
@@ -2,7 +2,7 @@
 # DO NOT EDIT
 #
 
-# deny any users listed here
+# deny any users or groups listed
 <% entries = scope.lookupvar('pam::denied_users') -%>
 <% if entries.is_a? Hash -%>
 <% entries.keys.sort.each do |key| -%>
@@ -17,7 +17,7 @@
 - : <%= entries %> : ALL
 <% end -%>
 
-# allow only the groups listed
+# allow only the users or groups listed
 <% entries = scope.lookupvar('pam::allowed_users') -%>
 <% if entries.is_a? Hash -%>
 <% entries.keys.sort.each do |key| -%>

--- a/templates/access.conf.erb
+++ b/templates/access.conf.erb
@@ -2,10 +2,23 @@
 # DO NOT EDIT
 #
 
+# deny any users listed here
+<% entries = scope.lookupvar('pam::denied_users') -%>
+<% if entries.is_a? Hash -%>
+<% entries.keys.sort.each do |key| -%>
+<% value = entries[key] -%>
+- : <%= key %> : <% if value.is_a? Array -%><%= value.join(' ') %><% elsif value.is_a? String -%><%= value %><% else -%>ALL<% end %>
+<% end -%>
+<% elsif entries.is_a? Array -%>
+<% entries.each do |key| -%>
+- : <%= key %> : ALL
+<% end -%>
+<% elsif entries.is_a? String -%>
+- : <%= entries %> : ALL
+<% end -%>
+
 # allow only the groups listed
-<%
-entries = scope.lookupvar('pam::allowed_users')
--%>
+<% entries = scope.lookupvar('pam::allowed_users') -%>
 <% if entries.is_a? Hash -%>
 <% entries.keys.sort.each do |key| -%>
 <% value = entries[key] -%>


### PR DESCRIPTION
Hi ghoneycutt, 

My organisation needed to be able to have a list of users who are explicitly denied in access.conf even if they are in an allowed group. I couldn't see support for this anywhere in your README so I've provided support for a denied_users (baddies list) parameter. Users or groups in this list will be denied regardless of if they are in the allowed groups.

I wanted to make the changes to access.conf.erb DRY, but I'm relatively new to using erb templates and using a 'def' caused me no end of errors where it seemed the interpreter was parsing the template wrong, so I decided to drop it for this which is functional. Perhaps you know a better way? 

I've modified your provided tests to incorporate the denied_users list. I understand that in some of the later tests you used .with_content(), (which I presume is because of the lack of consistent hash ordering), and this means that I couldn't test that the denied_users came before the allowed_users in the file without making the tests unreadable, which is not ideal. Otherwise the tests should all be fine and cover all cases. 

Thanks for the good work with the modules!
Regards,
Jetroid.
