### PR TITLE
Add param to manage nsswitch service from pam module.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ doc/
 # Vim
 *.swp
 
+# Eclipse
+.project
+
 # OS X
 .DS_Store
 

--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ Boolean to purge the limits.d directory.
 
 manage_nsswitch
 ------------------
-Boolean to manage nsswitch service.
+Boolean to manage the inclusion of the nsswitch class.
 
 - *Default*: true
 

--- a/README.md
+++ b/README.md
@@ -434,6 +434,12 @@ Boolean to purge the limits.d directory.
 
 - *Default*: false
 
+manage_nsswitch
+------------------
+Boolean to manage nsswitch service.
+
+- *Default*: true
+
 ===
 
 # pam::limits::fragment define

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,7 +53,13 @@ class pam (
   $manage_nsswitch                     = true,
 ) {
 
-  if $manage_nsswitch == true {
+  if is_string($manage_nsswitch) == true {
+    $manage_nsswitch_real = str2bool($manage_nsswitch)
+  } else {
+    $manage_nsswitch_real = $manage_nsswitch
+  }
+
+  if $manage_nsswitch_real == true {
     include ::nsswitch
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,9 +50,12 @@ class pam (
   $system_auth_ac_password_lines       = undef,
   $system_auth_ac_session_lines        = undef,
   $vas_major_version                   = '4',
+  $manage_nsswitch                     = true,
 ) {
 
-  include ::nsswitch
+  if $manage_nsswitch == true {
+    include ::nsswitch
+  }
 
   case $::osfamily {
     'RedHat': {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -788,7 +788,6 @@ describe 'pam' do
             :lsbdistid => v[:lsbdistid],
           }
         end
-        let(:params) { {:manage_nsswitch => true} }
         it { is_expected.to contain_class('nsswitch') }
       end
       

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -781,6 +781,39 @@ describe 'pam' do
         end
       end
 
+      context "with manage_nsswitch parameter default value" do
+        let :facts do
+          { :osfamily => v[:osfamily],
+            :"#{v[:releasetype]}" => v[:release],
+            :lsbdistid => v[:lsbdistid],
+          }
+        end
+        let(:params) { {:manage_nsswitch => true} }
+        it { is_expected.to contain_class('nsswitch') }
+      end
+      
+      context "with manage_nsswitch parameter set to true" do
+        let :facts do
+          { :osfamily => v[:osfamily],
+            :"#{v[:releasetype]}" => v[:release],
+            :lsbdistid => v[:lsbdistid],
+          }
+        end
+        let(:params) { {:manage_nsswitch => true} }
+        it { is_expected.to contain_class('nsswitch') }
+      end
+      
+      context "with manage_nsswitch parameter set to false" do 
+        let :facts do
+          { :osfamily => v[:osfamily],
+            :"#{v[:releasetype]}" => v[:release],
+            :lsbdistid => v[:lsbdistid],
+          }
+        end
+        let(:params) { {:manage_nsswitch => false} }
+        it { is_expected.not_to contain_class('nsswitch') }
+      end
+
       ['true',true,'false',false].each do |value|
         context "with limits_fragments_hiera_merge parameter specified as a valid value: #{value} on #{v[:osfamily]} with #{v[:releasetype]} #{v[:release]}" do
           let :facts do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -790,27 +790,31 @@ describe 'pam' do
         end
         it { is_expected.to contain_class('nsswitch') }
       end
-      
-      context "with manage_nsswitch parameter set to true" do
-        let :facts do
-          { :osfamily => v[:osfamily],
-            :"#{v[:releasetype]}" => v[:release],
-            :lsbdistid => v[:lsbdistid],
-          }
+
+      ['true', true, 'y'].each do |value|
+        context "with manage_nsswitch parameter set to #{value}" do
+          let :facts do
+            { :osfamily => v[:osfamily],
+              :"#{v[:releasetype]}" => v[:release],
+              :lsbdistid => v[:lsbdistid],
+            }
+          end
+          let(:params) { {:manage_nsswitch => value} }
+          it { is_expected.to contain_class('nsswitch') }
         end
-        let(:params) { {:manage_nsswitch => true} }
-        it { is_expected.to contain_class('nsswitch') }
       end
-      
-      context "with manage_nsswitch parameter set to false" do 
-        let :facts do
-          { :osfamily => v[:osfamily],
-            :"#{v[:releasetype]}" => v[:release],
-            :lsbdistid => v[:lsbdistid],
-          }
+
+      ['false', false, 'n'].each do |value|
+        context "with manage_nsswitch parameter set to #{value}" do
+          let :facts do
+            { :osfamily => v[:osfamily],
+              :"#{v[:releasetype]}" => v[:release],
+              :lsbdistid => v[:lsbdistid],
+            }
+          end
+          let(:params) { {:manage_nsswitch => value} }
+          it { is_expected.not_to contain_class('nsswitch') }
         end
-        let(:params) { {:manage_nsswitch => false} }
-        it { is_expected.not_to contain_class('nsswitch') }
       end
 
       ['true',true,'false',false].each do |value|


### PR DESCRIPTION
Default behaviour is to include nsswitch module inside pam module, this
param allow to use different way of configuration nsswitch service.
Backward compaltibility was kept (default: true).