### PR TITLE
Add template for performing custom sshd pam config

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,35 @@ pam_d_sshd_template
 -------------------
 Content template of $pam_d_sshd_path. If undef, parameter is set based on the OS version.
 
+For cases where a full customization of the sshd PAM configuration is required, set pam_d_sshd_template to use pam/sshd.custom.erb that is provided with this module.
+pam/sshd.custom.erb must be further configured with the parameters pam_sshd_auth_lines, pam_sshd_account_lines, pam_sshd_password_lines and pam_sshd_session_lines.
+Note that the pam_d_sshd_template parameter is a no-op on Solaris.
+
 - *Default*: undef, default is set based on OS version
+
+pam_sshd_auth_lines
+-------------------
+An ordered array of strings that define the content for PAM sshd auth. This setting is required and only valid if pam_d_sshd_template is configured to use the pam/sshd.custom.erb template.
+
+- *Default*: undef
+
+pam_sshd_account_lines
+----------------------
+An ordered array of strings that define the content for PAM sshd account. This setting is required and only valid if pam_d_sshd_template is configured to use the pam/sshd.custom.erb template.
+
+- *Default*: undef
+
+pam_sshd_password_lines
+-----------------------
+An ordered array of strings that define the content for PAM sshd password. This setting is required and only valid if pam_d_sshd_template is configured to use the pam/sshd.custom.erb template.
+
+- *Default*: undef
+
+pam_sshd_session_lines
+----------------------
+An ordered array of strings that define the content for PAM sshd session. This setting is required and only valid if pam_d_sshd_template is configured to use the pam/sshd.custom.erb template.
+
+- *Default*: undef
 
 pam_auth_lines
 --------------

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,10 @@ class pam (
   $pam_d_sshd_group                    = 'root',
   $pam_d_sshd_mode                     = '0644',
   $pam_d_sshd_template                 = undef,
+  $pam_sshd_auth_lines                 = undef,
+  $pam_sshd_account_lines              = undef,
+  $pam_sshd_password_lines             = undef,
+  $pam_sshd_session_lines              = undef,
   $pam_auth_lines                      = undef,
   $pam_account_lines                   = undef,
   $pam_password_lines                  = undef,
@@ -1111,6 +1115,26 @@ class pam (
     $my_pam_d_login_template = $default_pam_d_login_template
   } else {
     $my_pam_d_login_template = $pam_d_login_template
+  }
+
+  if $pam_d_sshd_template == 'pam/sshd.custom.erb' {
+    if $pam_sshd_auth_lines == undef or
+      $pam_sshd_account_lines == undef or
+      $pam_sshd_password_lines == undef or
+      $pam_sshd_session_lines == undef {
+        fail('pam_sshd_[auth|account|password|session]_lines required when using the pam/sshd.custom.erb template')
+    }
+    validate_array($pam_sshd_auth_lines)
+    validate_array($pam_sshd_account_lines)
+    validate_array($pam_sshd_password_lines)
+    validate_array($pam_sshd_session_lines)
+  } else {
+    if $pam_sshd_auth_lines != undef or
+      $pam_sshd_account_lines != undef or
+      $pam_sshd_password_lines != undef or
+      $pam_sshd_session_lines != undef {
+        fail('pam_sshd_[auth|account|password|session]_lines are only valid when pam_d_sshd_template is configured with the pam/sshd.custom.erb template')
+    }
   }
 
   if $pam_d_sshd_template == undef {

--- a/templates/sshd.custom.erb
+++ b/templates/sshd.custom.erb
@@ -1,0 +1,15 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+#
+<% @pam_sshd_auth_lines.each do |auth_line| -%>
+<%= auth_line %>
+<% end -%>
+<% @pam_sshd_account_lines.each do |account_line| -%>
+<%= account_line %>
+<% end -%>
+<% @pam_sshd_password_lines.each do |password_line| -%>
+<%= password_line %>
+<% end -%>
+<% @pam_sshd_session_lines.each do |session_line| -%>
+<%= session_line %>
+<% end -%>


### PR DESCRIPTION
Specific use case is to be able to supply options to pam_vas3 that are
specifically needed (and should only be configured) for sshd to resolv
intermittent ssh login failures with QAS.