### PR TITLE
Add pam::access_lines as a fallback mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,48 @@ This would create /etc/security/access.conf with the following content.
 + : username2 : tty1
 </pre>
 
+access_lines
+------------
+Array of String values, each string representing a complete text line in
+`/etc/security/access.conf`.  The purpose of this parameter is to configure a
+baseline set of access rules.  Entries from the `allow_users` parameter will go
+above entries specified in `allow_lines_fallback`, and the default deny-all
+entry will follow the entries specified in `allow_lines_fallback`.  Defaults to
+`['+ : root : crond :0 tty1 tty2 tty3 tty4 tty5 tty6']` which implements, "User
+root should be allowed to get access via cron, X11 terminal :0, tty1, ..., tty5,
+tty6."
+
+- *Default*: ['+ : root : crond :0 tty1 tty2 tty3 tty4 tty5 tty6']
+
+# Hiera example for access_lines
+<pre>
+# Allow devs to log in with a fallback of allowing ops and vagrant to log in
+# in the event pam::allowed_users gets overridden.
+pam::allowed_users:
+  - devs
+pam::access_lines:
+  - '+ : ops : ALL'
+  - '+ : vagrant : ALL'
+  - '+ : root : crond :0 tty1 tty2 tty3 tty4 tty5 tty6'
+</pre>
+
+This would create /etc/security/access.conf with the following content.
+<pre>
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+#
+
+# allow only the groups listed
++ : devs : ALL
+# pam::allowed_lines Array<String> fallback values
++ : ops : ALL
++ : vagrant : ALL
++ : root : crond :0 tty1 tty2 tty3 tty4 tty5 tty6'
+
+# default deby
+- : ALL : ALL
+</pre>
+
 login_pam_access
 ----------------
 Control module to be used for pam_access.so for login. Valid values are 'required', 'requisite', 'sufficient', 'optional' and 'absent'.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,7 @@
 #
 class pam (
   $allowed_users                       = 'root',
+  $access_lines                        = ['+ : root : crond :0 tty1 tty2 tty3 tty4 tty5 tty6'],
   $login_pam_access                    = 'required',
   $sshd_pam_access                     = 'required',
   $ensure_vas                          = 'absent',

--- a/spec/classes/accesslogin_spec.rb
+++ b/spec/classes/accesslogin_spec.rb
@@ -30,6 +30,8 @@ describe 'pam::accesslogin' do
 
 # allow only the groups listed
 + : root : ALL
+# pam::allowed_lines Array<String> fallback values
++ : root : crond :0 tty1 tty2 tty3 tty4 tty5 tty6
 
 # default deny
 - : ALL : ALL
@@ -70,6 +72,8 @@ describe 'pam::accesslogin' do
 # allow only the groups listed
 + : foo : ALL
 + : bar : ALL
+# pam::allowed_lines Array<String> fallback values
++ : root : crond :0 tty1 tty2 tty3 tty4 tty5 tty6
 
 # default deny
 - : ALL : ALL

--- a/templates/access.conf.erb
+++ b/templates/access.conf.erb
@@ -20,6 +20,9 @@ entries = scope.lookupvar('pam::allowed_users')
 <% else -%>
 + : root : ALL
 <% end -%>
+# pam::allowed_lines Array<String> fallback values
+<% access_lines = scope.lookupvar('pam::access_lines') -%>
+<%= access_lines.join("\n") %>
 
 # default deny
 - : ALL : ALL


### PR DESCRIPTION
Without this patch there isn't a good way to configure access rules at
different hierarchy levels, e.g. on a per-application development team basis.
Consider the situation where numerous different development teams need access
to the servers running their application.  Each team should not be allowed
access except to their own app servers.  There is an infrastructure team who
needs access to all servers.

This patch allows the infrastructure team to be listed in the
`pam::access_lines` hiera key in `common.yaml`.  App developer groups are
listed in `pam::allow_users` as normal and do not affect the rules applied to
all servers from common.yaml.

Hiera array merging is not ideal for this solution due to complexity and the
nature of allow_users potentially being a String, Array or Hash.