### PR TITLE
Use newer puppetlabs_spec_helper which does strict variable checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ env:
     - PUPPET_GEM_VERSION="~> 4.3.0"
     - PUPPET_GEM_VERSION="~> 4.4.0"
     - PUPPET_GEM_VERSION="~> 4.5.0"
-    - PUPPET_GEM_VERSION="~> 4" STRICT_VARIABLES="yes"
+    - PUPPET_GEM_VERSION="~> 4.6.0"
+    - PUPPET_GEM_VERSION="~> 4"
 
 sudo: false
 
@@ -57,7 +58,9 @@ matrix:
     - rvm: 1.8.7
       env: PUPPET_GEM_VERSION="~> 4.5.0"
     - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4" STRICT_VARIABLES="yes"
+      env: PUPPET_GEM_VERSION="~> 4.6.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4"
     - rvm: 2.3.1
       env: PUPPET_GEM_VERSION="~> 3.1.0"
     - rvm: 2.3.1

--- a/Gemfile
+++ b/Gemfile
@@ -7,16 +7,15 @@ else
 end
 
 gem 'metadata-json-lint'
-gem 'puppetlabs_spec_helper', '>= 1.1.1'
+gem 'puppetlabs_spec_helper', '>= 1.2.0'
 gem 'facter', '>= 1.7.0'
-gem 'rspec-puppet', '~> 2.0'
+gem 'rspec-puppet'
 gem 'puppet-lint', '>= 1.0', '< 3.0'
 gem 'puppet-lint-absolute_classname-check'
 gem 'puppet-lint-alias-check'
 gem 'puppet-lint-empty_string-check'
 gem 'puppet-lint-file_ensure-check'
 gem 'puppet-lint-file_source_rights-check'
-gem 'puppet-lint-fileserver-check'
 gem 'puppet-lint-leading_zero-check'
 gem 'puppet-lint-spaceship_operator_without_tag-check'
 gem 'puppet-lint-trailing_comma-check'
@@ -24,16 +23,7 @@ gem 'puppet-lint-undef_in_function-check'
 gem 'puppet-lint-unquoted_string-check'
 gem 'puppet-lint-variable_contains_upcase'
 
-if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
-  # rspec must be v2 for ruby 1.8.7
-  gem 'rspec', '~> 2.0'
-  # rake >= 11 does not support ruby 1.8.7
-  gem 'rake', '~> 10.0'
-end
-
-if RUBY_VERSION < '2.0'
-  # json 2.x requires ruby 2.0. Lock to 1.8
-  gem 'json', '~> 1.8'
-  # json_pure 2.0.2 requires ruby 2.0. Lock to 2.0.1
-  gem 'json_pure', '= 2.0.1'
-end
+gem 'rspec',     '~> 2.0'   if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+gem 'rake',      '~> 10.0'  if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+gem 'json',      '<= 1.8'   if RUBY_VERSION < '2.0.0'
+gem 'json_pure', '<= 2.0.1' if RUBY_VERSION < '2.0.0'


### PR DESCRIPTION
puppetlabs_spec_helper v1.2.0 introduced testing Puppet v4 with strict
variable checking by default.