### PR TITLE
Add support for raspbian, using the same code as debian

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -866,7 +866,7 @@ class pam (
             }
           }
         }
-        'Debian': {
+        'Debian', 'Raspbian': {
           case $::lsbmajdistrelease {
             /(7|8)/: {
 
@@ -909,7 +909,7 @@ class pam (
           }
         }
         default: {
-          fail("Pam is only supported on lsbdistid Ubuntu or Debian of the Debian osfamily. Your lsbdistid is <${::lsbdistid}>.")
+          fail("Pam is only supported on lsbdistid Ubuntu, Debian or Raspbian of the Debian osfamily. Your lsbdistid is <${::lsbdistid}>.")
         }
       }
     }


### PR DESCRIPTION
Since raspbian is, to all extents and purposes, the same as debian I'm using this module by additiona "Raspbian" to the same case in the lsbdistid switch.