### PR TITLE
Restrict users by default per SSH on Debian and Ubuntu distros.

### DIFF
--- a/spec/fixtures/pam_d_sshd.defaults.debian7
+++ b/spec/fixtures/pam_d_sshd.defaults.debian7
@@ -2,6 +2,7 @@ auth     required     pam_env.so # [1]
 auth     required     pam_env.so envfile=/etc/default/locale
 @include common-auth
 account  required     pam_nologin.so
+account  required     pam_access.so
 @include common-account
 @include common-session
 session  optional     pam_motd.so  motd=/run/motd.dynamic noupdate

--- a/spec/fixtures/pam_d_sshd.defaults.debian8
+++ b/spec/fixtures/pam_d_sshd.defaults.debian8
@@ -1,5 +1,6 @@
 @include common-auth
 account  required     pam_nologin.so
+account  required     pam_access.so
 @include common-account
 session  [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so close
 session  required     pam_loginuid.so

--- a/spec/fixtures/pam_d_sshd.defaults.ubuntu1204
+++ b/spec/fixtures/pam_d_sshd.defaults.ubuntu1204
@@ -2,6 +2,7 @@ auth       required     pam_env.so # [1]
 auth       required     pam_env.so envfile=/etc/default/locale
 @include common-auth
 account    required     pam_nologin.so
+account  required     pam_access.so
 @include common-account
 @include common-session
 session    optional     pam_motd.so # [1]

--- a/spec/fixtures/pam_d_sshd.defaults.ubuntu1404
+++ b/spec/fixtures/pam_d_sshd.defaults.ubuntu1404
@@ -1,5 +1,6 @@
 @include common-auth
 account  required     pam_nologin.so
+account  required     pam_access.so
 @include common-account
 session  [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so close
 session  required     pam_loginuid.so

--- a/spec/fixtures/pam_d_sshd.defaults.ubuntu1604
+++ b/spec/fixtures/pam_d_sshd.defaults.ubuntu1604
@@ -1,5 +1,6 @@
 @include common-auth
 account  required     pam_nologin.so
+account  required     pam_access.so
 @include common-account
 session  [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so close
 session  required     pam_loginuid.so

--- a/templates/sshd.debian7.erb
+++ b/templates/sshd.debian7.erb
@@ -2,6 +2,9 @@ auth     required     pam_env.so # [1]
 auth     required     pam_env.so envfile=/etc/default/locale
 @include common-auth
 account  required     pam_nologin.so
+<% if @sshd_pam_access != 'absent' -%>
+account  <%= @sshd_pam_access %>     pam_access.so
+<% end -%>
 @include common-account
 @include common-session
 session  optional     pam_motd.so  motd=/run/motd.dynamic noupdate

--- a/templates/sshd.debian8.erb
+++ b/templates/sshd.debian8.erb
@@ -1,5 +1,8 @@
 @include common-auth
 account  required     pam_nologin.so
+<% if @sshd_pam_access != 'absent' -%>
+account  <%= @sshd_pam_access %>     pam_access.so
+<% end -%>
 @include common-account
 session  [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so close
 session  required     pam_loginuid.so

--- a/templates/sshd.ubuntu12.erb
+++ b/templates/sshd.ubuntu12.erb
@@ -2,6 +2,9 @@ auth       required     pam_env.so # [1]
 auth       required     pam_env.so envfile=/etc/default/locale
 @include common-auth
 account    required     pam_nologin.so
+<% if @sshd_pam_access != 'absent' -%>
+account  <%= @sshd_pam_access %>     pam_access.so
+<% end -%>
 @include common-account
 @include common-session
 session    optional     pam_motd.so # [1]

--- a/templates/sshd.ubuntu14.erb
+++ b/templates/sshd.ubuntu14.erb
@@ -1,5 +1,8 @@
 @include common-auth
 account  required     pam_nologin.so
+<% if @sshd_pam_access != 'absent' -%>
+account  <%= @sshd_pam_access %>     pam_access.so
+<% end -%>
 @include common-account
 session  [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so close
 session  required     pam_loginuid.so

--- a/templates/sshd.ubuntu16.erb
+++ b/templates/sshd.ubuntu16.erb
@@ -1,5 +1,8 @@
 @include common-auth
 account  required     pam_nologin.so
+<% if @sshd_pam_access != 'absent' -%>
+account  <%= @sshd_pam_access %>     pam_access.so
+<% end -%>
 @include common-account
 session  [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so close
 session  required     pam_loginuid.so


### PR DESCRIPTION
Load the module 'pam_access.so' by default on all Debian and Ubuntu
platforms because users were not restricted on SSH connections.