### PR TITLE
Drop puppet 3 support and use data types for parameters

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,7 @@ fixtures:
   repositories:
     stdlib:
       repo: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
-      ref: '4.6.0'
+      ref: '4.13.1'
     common:
       repo: 'https://github.com/ghoneycutt/puppet-module-common.git'
       ref: 'v1.4.1'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,110 +1,37 @@
 ---
 language: ruby
 
-rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
-  - 2.1.9
-  - 2.3.1
+bundler_args: --without system_tests development
 
-env:
-  matrix:
-    - PUPPET_GEM_VERSION="~> 3.1.0"
-    - PUPPET_GEM_VERSION="~> 3.2.0"
-    - PUPPET_GEM_VERSION="~> 3.3.0"
-    - PUPPET_GEM_VERSION="~> 3.4.0"
-    - PUPPET_GEM_VERSION="~> 3.5.0"
-    - PUPPET_GEM_VERSION="~> 3.6.0"
-    - PUPPET_GEM_VERSION="~> 3.7.0"
-    - PUPPET_GEM_VERSION="~> 3.8.0"
-    - PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
-    - PUPPET_GEM_VERSION="~> 4.0.0"
-    - PUPPET_GEM_VERSION="~> 4.1.0"
-    - PUPPET_GEM_VERSION="~> 4.2.0"
-    - PUPPET_GEM_VERSION="~> 4.3.0"
-    - PUPPET_GEM_VERSION="~> 4.4.0"
-    - PUPPET_GEM_VERSION="~> 4.5.0"
-    - PUPPET_GEM_VERSION="~> 4.6.0"
-    - PUPPET_GEM_VERSION="~> 4.7.0"
-    - PUPPET_GEM_VERSION="~> 4.8.0"
-    - PUPPET_GEM_VERSION="~> 4.9.0"
-    - PUPPET_GEM_VERSION="~> 4.10.0"
-    - PUPPET_GEM_VERSION="~> 4"
+cache: bundler
+
+before_install:
+  - bundle -v
+  - rm Gemfile.lock || true
+  - gem update --system
+  - gem update bundler
+  - gem --version
+  - bundle -v
 
 sudo: false
 
-script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec'
+script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec strings:generate'
 
 matrix:
   fast_finish: true
-  exclude:
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 3.1.0"
-    - rvm: 2.1.9
-      env: PUPPET_GEM_VERSION="~> 3.1.0"
-    - rvm: 2.1.9
-      env: PUPPET_GEM_VERSION="~> 3.2.0"
-    - rvm: 2.1.9
-      env: PUPPET_GEM_VERSION="~> 3.3.0"
-    - rvm: 2.1.9
-      env: PUPPET_GEM_VERSION="~> 3.4.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.0.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.1.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.2.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.3.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.4.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.5.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.6.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.7.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.8.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.9.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.10.0"
-    - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 4.9.0"
-    - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 4.10.0"
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 4.9.0"
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 4.10.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4"
-    - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 4"
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 4"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.1.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.2.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.3.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.4.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.5.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.6.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.7.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.8.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
-  allow_failures:
-    - rvm: 2.3.1
+  include:
+  - rvm: 2.1.9
+    env: PUPPET_GEM_VERSION="~> 4"
+  - rvm: 2.4.1
+    env: PUPPET_GEM_VERSION="~> 5.0.0"
+  - rvm: 2.4.1
+    env: PUPPET_GEM_VERSION="~> 5.1.0"
+  - rvm: 2.4.1
+    env: PUPPET_GEM_VERSION="~> 5.2.0"
+  - rvm: 2.4.1
+    env: PUPPET_GEM_VERSION="~> 5.3.0"
+  - rvm: 2.4.1
+    env: PUPPET_GEM_VERSION="~> 5"
 
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -31,3 +31,9 @@ gem 'metadata-json-lint'             if RUBY_VERSION >= '1.9'
 gem 'puppetlabs_spec_helper', '2.0.2',    :require => false if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
 gem 'puppetlabs_spec_helper', '>= 2.0.0', :require => false if RUBY_VERSION >= '1.9'
 gem 'parallel_tests',         '<= 2.9.0', :require => false if RUBY_VERSION < '2.0.0'
+
+group :documentation do
+  gem 'yard',           require: false
+  gem 'redcarpet',      require: false
+  gem 'puppet-strings', require: false
+end

--- a/README.md
+++ b/README.md
@@ -316,30 +316,6 @@ Path to system-auth-ac. Used on RedHat.
 
 - *Default*: '/etc/pam.d/system-auth-ac'
 
-system_auth_ac_auth_lines
--------------------------
-Content template of $system_auth_ac_file. If undef, parameter is set based on the OS version.
-
-- *Default*: undef, default is set based on OS version
-
-system_auth_ac_account_lines
-----------------------------
-Content template of $system_auth_ac_file. If undef, parameter is set based on the OS version.
-
-- *Default*: undef, default is set based on OS version
-
-system_auth_ac_password_lines
------------------------------
-Content template of $system_auth_ac_file. If undef, parameter is set based on the OS version.
-
-- *Default*: undef, default is set based on OS version
-
-system_auth_ac_session_lines
-----------------------------
-Content template of $system_auth_ac_file. If undef, parameter is set based on the OS version.
-
-- *Default*: undef, default is set based on OS version
-
 password_auth_file
 ----------------
 Path to password-auth. Used on RedHat.

--- a/Rakefile
+++ b/Rakefile
@@ -17,3 +17,10 @@ task :validate do
     sh "erb -P -x -T '-' #{template} | ruby -c"
   end
 end
+
+# Puppet Strings (Documentation generation from inline comments)
+# See: https://github.com/puppetlabs/puppet-strings#rake-tasks
+require 'puppet-strings/tasks'
+
+desc 'Alias for strings:generate'
+task :doc => ['strings:generate']

--- a/manifests/accesslogin.pp
+++ b/manifests/accesslogin.pp
@@ -5,11 +5,11 @@
 # See PAM_ACCESS(8)
 #
 class pam::accesslogin (
-  $access_conf_path     = '/etc/security/access.conf',
-  $access_conf_owner    = 'root',
-  $access_conf_group    = 'root',
-  $access_conf_mode     = '0644',
-  $access_conf_template = 'pam/access.conf.erb',
+  Stdlib::Absolutepath $access_conf_path  = '/etc/security/access.conf',
+  String $access_conf_owner               = 'root',
+  String $access_conf_group               = 'root',
+  Pattern[/^[0-7]{4}$/] $access_conf_mode = '0644',
+  String $access_conf_template            = 'pam/access.conf.erb',
 ) {
 
   require '::pam'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1131,115 +1131,115 @@ class pam (
     }
   }
 
-  if $package_name == undef {
-    $my_package_name = $default_package_name
-  } else {
+  if $package_name {
     $my_package_name = $package_name
+  } else {
+    $my_package_name = $default_package_name
   }
 
-  if $pam_d_login_template == undef {
-    $my_pam_d_login_template = $default_pam_d_login_template
-  } else {
+  if $pam_d_login_template {
     $my_pam_d_login_template = $pam_d_login_template
+  } else {
+    $my_pam_d_login_template = $default_pam_d_login_template
   }
 
   if $pam_d_sshd_template == 'pam/sshd.custom.erb' {
-    if $pam_sshd_auth_lines == undef or
-      $pam_sshd_account_lines == undef or
-      $pam_sshd_password_lines == undef or
-      $pam_sshd_session_lines == undef {
+    unless $pam_sshd_auth_lines and
+      $pam_sshd_account_lines and
+      $pam_sshd_password_lines and
+      $pam_sshd_session_lines {
         fail('pam_sshd_[auth|account|password|session]_lines required when using the pam/sshd.custom.erb template')
     }
   } else {
-    if $pam_sshd_auth_lines != undef or
-      $pam_sshd_account_lines != undef or
-      $pam_sshd_password_lines != undef or
-      $pam_sshd_session_lines != undef {
+    if $pam_sshd_auth_lines or
+      $pam_sshd_account_lines or
+      $pam_sshd_password_lines or
+      $pam_sshd_session_lines {
         fail('pam_sshd_[auth|account|password|session]_lines are only valid when pam_d_sshd_template is configured with the pam/sshd.custom.erb template')
     }
   }
 
-  if $pam_d_sshd_template == undef {
-    $my_pam_d_sshd_template = $default_pam_d_sshd_template
-  } else {
+  if $pam_d_sshd_template {
     $my_pam_d_sshd_template = $pam_d_sshd_template
+  } else {
+    $my_pam_d_sshd_template = $default_pam_d_sshd_template
   }
 
-  if $pam_auth_lines == undef {
-    if $system_auth_ac_auth_lines == undef {
-      $my_pam_auth_lines = $default_pam_auth_lines
-    } else {
+  if $pam_auth_lines {
+    $my_pam_auth_lines = $pam_auth_lines
+  } else {
+    if $system_auth_ac_auth_lines {
       $my_pam_auth_lines = $system_auth_ac_auth_lines
       notify { 'Deprecation notice: `$system_auth_ac_auth_lines` has been deprecated in `pam` class and will be removed in a future version. Use $pam_auth_lines instead.': }
+    } else {
+      $my_pam_auth_lines = $default_pam_auth_lines
     }
-  } else {
-    $my_pam_auth_lines = $pam_auth_lines
   }
 
-  if $pam_account_lines == undef {
-    if $system_auth_ac_account_lines == undef {
-      $my_pam_account_lines = $default_pam_account_lines
-    } else {
+  if $pam_account_lines {
+    $my_pam_account_lines = $pam_account_lines
+  } else {
+    if $system_auth_ac_account_lines {
       $my_pam_account_lines = $system_auth_ac_account_lines
       notify { 'Deprecation notice: `$system_auth_ac_account_lines` has been deprecated in `pam` class and will be removed in a future version. Use $pam_account_lines instead.': }
+    } else {
+      $my_pam_account_lines = $default_pam_account_lines
     }
-  } else {
-    $my_pam_account_lines = $pam_account_lines
   }
 
-  if $pam_password_lines == undef {
-    if $system_auth_ac_password_lines == undef {
-      $my_pam_password_lines = $default_pam_password_lines
-    } else {
+  if $pam_password_lines {
+    $my_pam_password_lines = $pam_password_lines
+  } else {
+    if $system_auth_ac_password_lines {
       $my_pam_password_lines = $system_auth_ac_password_lines
       notify { 'Deprecation notice: `$system_auth_ac_password_lines` has been deprecated in `pam` class and will be removed in a future version. Use $pam_password_lines instead.': }
+    } else {
+      $my_pam_password_lines = $default_pam_password_lines
     }
-  } else {
-    $my_pam_password_lines = $pam_password_lines
   }
 
-  if $pam_session_lines == undef {
-    if $system_auth_ac_session_lines == undef {
-      $my_pam_session_lines = $default_pam_session_lines
-    } else {
+  if $pam_session_lines {
+    $my_pam_session_lines = $pam_session_lines
+  } else {
+    if $system_auth_ac_session_lines {
       $my_pam_session_lines = $system_auth_ac_session_lines
       notify { 'Deprecation notice: `$system_auth_ac_session_lines` has been deprecated in `pam` class and will be removed in a future version. Use $pam_session_lines instead.': }
+    } else {
+      $my_pam_session_lines = $default_pam_session_lines
     }
-  } else {
-    $my_pam_session_lines = $pam_session_lines
   }
 
   if ( $::osfamily == 'RedHat' ) and ( $::operatingsystemmajrelease == '6' or $::operatingsystemmajrelease == '7' ) {
-    if $pam_password_auth_lines == undef {
-      $my_pam_password_auth_lines = $default_pam_password_auth_lines
-    } else {
+    if $pam_password_auth_lines {
       $my_pam_password_auth_lines = $pam_password_auth_lines
+    } else {
+      $my_pam_password_auth_lines = $default_pam_password_auth_lines
     }
 
-    if $pam_password_account_lines == undef {
-      $my_pam_password_account_lines = $default_pam_password_account_lines
-    } else {
+    if $pam_password_account_lines {
       $my_pam_password_account_lines = $pam_password_account_lines
+    } else {
+      $my_pam_password_account_lines = $default_pam_password_account_lines
     }
 
-    if $pam_password_password_lines == undef {
-      $my_pam_password_password_lines = $default_pam_password_password_lines
-    } else {
+    if $pam_password_password_lines {
       $my_pam_password_password_lines = $pam_password_password_lines
+    } else {
+      $my_pam_password_password_lines = $default_pam_password_password_lines
     }
 
-    if $pam_password_session_lines == undef {
-      $my_pam_password_session_lines = $default_pam_password_session_lines
-    } else {
+    if $pam_password_session_lines {
       $my_pam_password_session_lines = $pam_password_session_lines
+    } else {
+      $my_pam_password_session_lines = $default_pam_password_session_lines
     }
   }
 
-  if $services != undef {
+  if $services {
     create_resources('pam::service',$services)
   }
 
-  if $limits_fragments != undef {
+  if $limits_fragments {
     if $limits_fragments_hiera_merge {
       $limits_fragments_real = hiera_hash('pam::limits_fragments')
     } else {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,10 +51,6 @@ class pam (
   Optional[Array] $pam_password_account_lines               = undef,
   Optional[Array] $pam_password_password_lines              = undef,
   Optional[Array] $pam_password_session_lines               = undef,
-  Optional[Array] $system_auth_ac_auth_lines                = undef,
-  Optional[Array] $system_auth_ac_account_lines             = undef,
-  Optional[Array] $system_auth_ac_password_lines            = undef,
-  Optional[Array] $system_auth_ac_session_lines             = undef,
   Enum['3', '4'] $vas_major_version                         = '4',
   Boolean $manage_nsswitch                                  = true,
 ) {
@@ -1168,45 +1164,25 @@ class pam (
   if $pam_auth_lines {
     $my_pam_auth_lines = $pam_auth_lines
   } else {
-    if $system_auth_ac_auth_lines {
-      $my_pam_auth_lines = $system_auth_ac_auth_lines
-      notify { 'Deprecation notice: `$system_auth_ac_auth_lines` has been deprecated in `pam` class and will be removed in a future version. Use $pam_auth_lines instead.': }
-    } else {
-      $my_pam_auth_lines = $default_pam_auth_lines
-    }
+    $my_pam_auth_lines = $default_pam_auth_lines
   }
 
   if $pam_account_lines {
     $my_pam_account_lines = $pam_account_lines
   } else {
-    if $system_auth_ac_account_lines {
-      $my_pam_account_lines = $system_auth_ac_account_lines
-      notify { 'Deprecation notice: `$system_auth_ac_account_lines` has been deprecated in `pam` class and will be removed in a future version. Use $pam_account_lines instead.': }
-    } else {
-      $my_pam_account_lines = $default_pam_account_lines
-    }
+    $my_pam_account_lines = $default_pam_account_lines
   }
 
   if $pam_password_lines {
     $my_pam_password_lines = $pam_password_lines
   } else {
-    if $system_auth_ac_password_lines {
-      $my_pam_password_lines = $system_auth_ac_password_lines
-      notify { 'Deprecation notice: `$system_auth_ac_password_lines` has been deprecated in `pam` class and will be removed in a future version. Use $pam_password_lines instead.': }
-    } else {
-      $my_pam_password_lines = $default_pam_password_lines
-    }
+    $my_pam_password_lines = $default_pam_password_lines
   }
 
   if $pam_session_lines {
     $my_pam_session_lines = $pam_session_lines
   } else {
-    if $system_auth_ac_session_lines {
-      $my_pam_session_lines = $system_auth_ac_session_lines
-      notify { 'Deprecation notice: `$system_auth_ac_session_lines` has been deprecated in `pam` class and will be removed in a future version. Use $pam_session_lines instead.': }
-    } else {
-      $my_pam_session_lines = $default_pam_session_lines
-    }
+    $my_pam_session_lines = $default_pam_session_lines
   }
 
   if ( $::osfamily == 'RedHat' ) and ( $::operatingsystemmajrelease == '6' or $::operatingsystemmajrelease == '7' ) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,67 +3,63 @@
 # This module manages bits around PAM.
 #
 class pam (
-  $allowed_users                       = 'root',
-  $login_pam_access                    = 'required',
-  $sshd_pam_access                     = 'required',
-  $ensure_vas                          = 'absent',
-  $package_name                        = undef,
-  $pam_conf_file                       = '/etc/pam.conf',
-  $services                            = undef,
-  $limits_fragments                    = undef,
-  $limits_fragments_hiera_merge        = false,
-  $pam_d_login_oracle_options          = 'UNSET',
-  $pam_d_login_path                    = '/etc/pam.d/login',
-  $pam_d_login_owner                   = 'root',
-  $pam_d_login_group                   = 'root',
-  $pam_d_login_mode                    = '0644',
-  $pam_d_login_template                = undef,
-  $pam_d_sshd_path                     = '/etc/pam.d/sshd',
-  $pam_d_sshd_owner                    = 'root',
-  $pam_d_sshd_group                    = 'root',
-  $pam_d_sshd_mode                     = '0644',
-  $pam_d_sshd_template                 = undef,
-  $pam_sshd_auth_lines                 = undef,
-  $pam_sshd_account_lines              = undef,
-  $pam_sshd_password_lines             = undef,
-  $pam_sshd_session_lines              = undef,
-  $pam_auth_lines                      = undef,
-  $pam_account_lines                   = undef,
-  $pam_password_lines                  = undef,
-  $pam_session_lines                   = undef,
-  $pam_d_other_file                    = '/etc/pam.d/other',
-  $common_auth_file                    = '/etc/pam.d/common-auth',
-  $common_auth_pc_file                 = '/etc/pam.d/common-auth-pc',
-  $common_account_file                 = '/etc/pam.d/common-account',
-  $common_account_pc_file              = '/etc/pam.d/common-account-pc',
-  $common_password_file                = '/etc/pam.d/common-password',
-  $common_password_pc_file             = '/etc/pam.d/common-password-pc',
-  $common_session_file                 = '/etc/pam.d/common-session',
-  $common_session_pc_file              = '/etc/pam.d/common-session-pc',
-  $common_session_noninteractive_file  = '/etc/pam.d/common-session-noninteractive',
-  $system_auth_file                    = '/etc/pam.d/system-auth',
-  $system_auth_ac_file                 = '/etc/pam.d/system-auth-ac',
-  $password_auth_file                  = '/etc/pam.d/password-auth',
-  $password_auth_ac_file               = '/etc/pam.d/password-auth-ac',
-  $pam_password_auth_lines             = undef,
-  $pam_password_account_lines          = undef,
-  $pam_password_password_lines         = undef,
-  $pam_password_session_lines          = undef,
-  $system_auth_ac_auth_lines           = undef,
-  $system_auth_ac_account_lines        = undef,
-  $system_auth_ac_password_lines       = undef,
-  $system_auth_ac_session_lines        = undef,
-  $vas_major_version                   = '4',
-  $manage_nsswitch                     = true,
+  Variant[String, Array, Hash] $allowed_users               = 'root',
+  Enum['required', 'requisite', 'sufficient', 'optional', 'absent']
+    $login_pam_access                                       = 'required',
+  Enum['required', 'requisite', 'sufficient', 'optional', 'absent']
+    $sshd_pam_access                                        = 'required',
+  Enum['present', 'absent'] $ensure_vas                     = 'absent',
+  Optional[Variant[String, Array]] $package_name            = undef,
+  Stdlib::Absolutepath $pam_conf_file                       = '/etc/pam.conf',
+  Optional[Hash] $services                                  = undef,
+  Optional[Hash] $limits_fragments                          = undef,
+  Boolean $limits_fragments_hiera_merge                     = false,
+  Variant[Array, Enum['UNSET']] $pam_d_login_oracle_options = 'UNSET',
+  Stdlib::Absolutepath $pam_d_login_path                    = '/etc/pam.d/login',
+  String $pam_d_login_owner                                 = 'root',
+  String $pam_d_login_group                                 = 'root',
+  Pattern[/^[0-7]{4}$/] $pam_d_login_mode                   = '0644',
+  Optional[String] $pam_d_login_template                    = undef,
+  Stdlib::Absolutepath $pam_d_sshd_path                     = '/etc/pam.d/sshd',
+  String $pam_d_sshd_owner                                  = 'root',
+  String $pam_d_sshd_group                                  = 'root',
+  Pattern[/^[0-7]{4}$/] $pam_d_sshd_mode                    = '0644',
+  Optional[String] $pam_d_sshd_template                     = undef,
+  Optional[Array] $pam_sshd_auth_lines                      = undef,
+  Optional[Array] $pam_sshd_account_lines                   = undef,
+  Optional[Array] $pam_sshd_password_lines                  = undef,
+  Optional[Array] $pam_sshd_session_lines                   = undef,
+  Optional[Array] $pam_auth_lines                           = undef,
+  Optional[Array] $pam_account_lines                        = undef,
+  Optional[Array] $pam_password_lines                       = undef,
+  Optional[Array] $pam_session_lines                        = undef,
+  Stdlib::Absolutepath $pam_d_other_file                    = '/etc/pam.d/other',
+  Stdlib::Absolutepath $common_auth_file                    = '/etc/pam.d/common-auth',
+  Stdlib::Absolutepath $common_auth_pc_file                 = '/etc/pam.d/common-auth-pc',
+  Stdlib::Absolutepath $common_account_file                 = '/etc/pam.d/common-account',
+  Stdlib::Absolutepath $common_account_pc_file              = '/etc/pam.d/common-account-pc',
+  Stdlib::Absolutepath $common_password_file                = '/etc/pam.d/common-password',
+  Stdlib::Absolutepath $common_password_pc_file             = '/etc/pam.d/common-password-pc',
+  Stdlib::Absolutepath $common_session_file                 = '/etc/pam.d/common-session',
+  Stdlib::Absolutepath $common_session_pc_file              = '/etc/pam.d/common-session-pc',
+  Stdlib::Absolutepath $common_session_noninteractive_file  = '/etc/pam.d/common-session-noninteractive',
+  Stdlib::Absolutepath $system_auth_file                    = '/etc/pam.d/system-auth',
+  Stdlib::Absolutepath $system_auth_ac_file                 = '/etc/pam.d/system-auth-ac',
+  Stdlib::Absolutepath $password_auth_file                  = '/etc/pam.d/password-auth',
+  Stdlib::Absolutepath $password_auth_ac_file               = '/etc/pam.d/password-auth-ac',
+  Optional[Array] $pam_password_auth_lines                  = undef,
+  Optional[Array] $pam_password_account_lines               = undef,
+  Optional[Array] $pam_password_password_lines              = undef,
+  Optional[Array] $pam_password_session_lines               = undef,
+  Optional[Array] $system_auth_ac_auth_lines                = undef,
+  Optional[Array] $system_auth_ac_account_lines             = undef,
+  Optional[Array] $system_auth_ac_password_lines            = undef,
+  Optional[Array] $system_auth_ac_session_lines             = undef,
+  Enum['3', '4'] $vas_major_version                         = '4',
+  Boolean $manage_nsswitch                                  = true,
 ) {
 
-  if is_string($manage_nsswitch) == true {
-    $manage_nsswitch_real = str2bool($manage_nsswitch)
-  } else {
-    $manage_nsswitch_real = $manage_nsswitch
-  }
-
-  if $manage_nsswitch_real == true {
+  if $manage_nsswitch {
     include ::nsswitch
   }
 
@@ -1135,21 +1131,6 @@ class pam (
     }
   }
 
-  $valid_pam_access_values = ['^required$', '^requisite$', '^sufficient$', '^optional$', '^absent$']
-
-  validate_re($login_pam_access, $valid_pam_access_values,
-    "pam::login_pam_access is <${login_pam_access}> and must be either 'required', 'requisite', 'sufficient', 'optional' or 'absent'.")
-
-  validate_re($sshd_pam_access, $valid_pam_access_values,
-    "pam::sshd_pam_access is <${sshd_pam_access}> and must be either 'required', 'requisite', 'sufficient', 'optional' or 'absent'.")
-
-  if is_string($limits_fragments_hiera_merge) == true {
-    $limits_fragments_hiera_merge_real = str2bool($limits_fragments_hiera_merge)
-  } else {
-    $limits_fragments_hiera_merge_real = $limits_fragments_hiera_merge
-  }
-  validate_bool($limits_fragments_hiera_merge_real)
-
   if $package_name == undef {
     $my_package_name = $default_package_name
   } else {
@@ -1169,10 +1150,6 @@ class pam (
       $pam_sshd_session_lines == undef {
         fail('pam_sshd_[auth|account|password|session]_lines required when using the pam/sshd.custom.erb template')
     }
-    validate_array($pam_sshd_auth_lines)
-    validate_array($pam_sshd_account_lines)
-    validate_array($pam_sshd_password_lines)
-    validate_array($pam_sshd_session_lines)
   } else {
     if $pam_sshd_auth_lines != undef or
       $pam_sshd_account_lines != undef or
@@ -1238,28 +1215,24 @@ class pam (
     } else {
       $my_pam_password_auth_lines = $pam_password_auth_lines
     }
-    validate_array($my_pam_password_auth_lines)
 
     if $pam_password_account_lines == undef {
       $my_pam_password_account_lines = $default_pam_password_account_lines
     } else {
       $my_pam_password_account_lines = $pam_password_account_lines
     }
-    validate_array($my_pam_password_account_lines)
 
     if $pam_password_password_lines == undef {
       $my_pam_password_password_lines = $default_pam_password_password_lines
     } else {
       $my_pam_password_password_lines = $pam_password_password_lines
     }
-    validate_array($my_pam_password_password_lines)
 
     if $pam_password_session_lines == undef {
       $my_pam_password_session_lines = $default_pam_password_session_lines
     } else {
       $my_pam_password_session_lines = $pam_password_session_lines
     }
-    validate_array($my_pam_password_session_lines)
   }
 
   if $services != undef {
@@ -1267,16 +1240,13 @@ class pam (
   }
 
   if $limits_fragments != undef {
-    if $limits_fragments_hiera_merge_real == true {
+    if $limits_fragments_hiera_merge {
       $limits_fragments_real = hiera_hash('pam::limits_fragments')
     } else {
       $limits_fragments_real = $limits_fragments
     }
     create_resources('pam::limits::fragment',$limits_fragments_real)
   }
-
-  validate_absolute_path($password_auth_ac_file)
-  validate_absolute_path($password_auth_file)
 
   case $::osfamily {
     'RedHat', 'Suse', 'Debian': {

--- a/manifests/limits.pp
+++ b/manifests/limits.pp
@@ -14,18 +14,18 @@ class pam::limits (
 
   include ::pam
 
-  if $config_file_lines == undef and $config_file_source == undef {
-    $content = template('pam/limits.conf.erb')
-    $config_file_source_real = undef
-  } else {
+  if $config_file_lines or $config_file_source {
     # config_file_lines takes priority over config_file_source
-    if $config_file_lines == undef {
-      $content = undef
-      $config_file_source_real = $config_file_source
-    } else {
+    if $config_file_lines {
       $config_file_source_real = undef
       $content = template('pam/limits.conf.erb')
+    } else {
+      $content = undef
+      $config_file_source_real = $config_file_source
     }
+  } else {
+    $content = template('pam/limits.conf.erb')
+    $config_file_source_real = undef
   }
   if $::osfamily == 'Suse' and $::lsbmajdistrelease == '10'  {
   } else {

--- a/manifests/limits.pp
+++ b/manifests/limits.pp
@@ -3,31 +3,14 @@
 # Manage PAM limits.conf
 #
 class pam::limits (
-  $config_file          = '/etc/security/limits.conf',
-  $config_file_lines    = undef,
-  $config_file_source   = undef,
-  $config_file_mode     = '0640',
-  $limits_d_dir         = '/etc/security/limits.d',
-  $limits_d_dir_mode    = '0750',
-  $purge_limits_d_dir   = false,
+  Stdlib::Absolutepath $config_file             = '/etc/security/limits.conf',
+  Optional[Array] $config_file_lines            = undef,
+  Optional[String] $config_file_source          = undef,
+  Pattern[/^[0-7]{4}$/] $config_file_mode       = '0640',
+  Stdlib::Absolutepath $limits_d_dir            = '/etc/security/limits.d',
+  Pattern[/^[0-7]{4}$/] $limits_d_dir_mode      = '0750',
+  Boolean $purge_limits_d_dir                   = false,
 ) {
-
-  # validate params
-  validate_absolute_path($config_file)
-  validate_absolute_path($limits_d_dir)
-
-  validate_re($config_file_mode, '^[0-7]{4}$',
-    "pam::limits::config_file_mode is <${config_file_mode}> and must be a valid four digit mode in octal notation.")
-
-  validate_re($limits_d_dir_mode, '^[0-7]{4}$',
-    "pam::limits::limits_d_dir_mode is <${limits_d_dir_mode}> and must be a valid four digit mode in octal notation.")
-
-  if is_string($purge_limits_d_dir) == true {
-    $purge_limits_d_dir_real = str2bool($purge_limits_d_dir)
-  } else {
-    $purge_limits_d_dir_real = $purge_limits_d_dir
-  }
-  validate_bool($purge_limits_d_dir_real)
 
   include ::pam
 
@@ -41,7 +24,6 @@ class pam::limits (
       $config_file_source_real = $config_file_source
     } else {
       $config_file_source_real = undef
-      validate_array($config_file_lines)
       $content = template('pam/limits.conf.erb')
     }
   }
@@ -54,8 +36,8 @@ class pam::limits (
       owner   => 'root',
       group   => 'root',
       mode    => $limits_d_dir_mode,
-      purge   => $purge_limits_d_dir_real,
-      recurse => $purge_limits_d_dir_real,
+      purge   => $purge_limits_d_dir,
+      recurse => $purge_limits_d_dir,
       require => [ Package[$::pam::my_package_name],
                   Common::Mkdir_p[$limits_d_dir],
                   ],

--- a/manifests/limits/fragment.pp
+++ b/manifests/limits/fragment.pp
@@ -3,9 +3,10 @@
 # Places a fragment in $limits_d_dir directory
 #
 define pam::limits::fragment (
-  $source = 'UNSET',
-  $list   = undef,
-  $ensure = 'file',
+  String $source          = 'UNSET',
+  Optional[Array] $list   = undef,
+  Enum['file', 'present', 'absent']
+    $ensure               = 'file',
 ) {
 
   include ::pam
@@ -31,12 +32,8 @@ define pam::limits::fragment (
   if $list == undef {
     $content = undef
   } else {
-    validate_array($list)
     $content = template('pam/limits_fragment.erb')
   }
-
-  validate_re($ensure, ['^file$', '^present$', '^absent$'],
-      "pam::limits::fragment::ensure <${ensure}> and must be either 'file', 'present' or 'absent'.")
 
   file { "${pam::limits::limits_d_dir}/${name}.conf":
     ensure  => $ensure,

--- a/manifests/limits/fragment.pp
+++ b/manifests/limits/fragment.pp
@@ -17,22 +17,18 @@ define pam::limits::fragment (
   }
 
   # must specify source or list
-  if $ensure != 'absent' and $source == 'UNSET' and $list == undef {
+  if $ensure != 'absent' and $source == 'UNSET' and ! $list {
     fail('pam::limits::fragment must specify source or list.')
   }
 
   # list takes priority if you specify both
-  if $list == undef {
-    $source_real = $source
-  } else {
-    $source_real = undef
-  }
-
   # use the template if a list is provided
-  if $list == undef {
-    $content = undef
-  } else {
+  if $list {
+    $source_real = undef
     $content = template('pam/limits_fragment.erb')
+  } else {
+    $source_real = $source
+    $content = undef
   }
 
   file { "${pam::limits::limits_d_dir}/${name}.conf":

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,15 +3,13 @@
 # Manage PAM file for a specifc service
 #
 define pam::service (
-  $ensure         = 'present',
-  $pam_config_dir = '/etc/pam.d',
-  $content        = undef,
-  $lines          = undef
+  Enum['present', 'absent'] $ensure     = 'present',
+  Stdlib::Absolutepath $pam_config_dir  = '/etc/pam.d',
+  Optional[String] $content             = undef,
+  Optional[Array] $lines                = undef
 ) {
 
   include ::pam
-
-  validate_re($ensure, ['^present$', '^absent$'] )
 
   case $ensure {
     'present': {

--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 4.7.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -98,6 +98,6 @@
   "dependencies": [
     {"name":"ghoneycutt/common","version_requirement":">= 1.4.1 < 2.0.0"},
     {"name":"ghoneycutt/nsswitch","version_requirement":">= 1.3.0 < 2.0.0"},
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 5.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.13.1 < 5.0.0"}
   ]
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -567,7 +567,7 @@ describe 'pam' do
           it 'should fail' do
             expect {
               should contain_class('pam')
-            }.to raise_error(Puppet::Error, /"invalid\/path" is not an absolute path/)
+            }.to raise_error(Puppet::Error, /Evaluation Error: Error while evaluating a Resource Statement/)
           end
 
         end
@@ -586,7 +586,7 @@ describe 'pam' do
           it 'should fail' do
             expect {
               should contain_class('pam')
-            }.to raise_error(Puppet::Error, /"invalid\/path" is not an absolute path/)
+            }.to raise_error(Puppet::Error, /Evaluation Error: Error while evaluating a Resource Statement/)
           end
 
         end
@@ -722,20 +722,10 @@ describe 'pam' do
           }
         end
 
-        if v[:osfamily] == 'RedHat'
-          if v[:release] == '5' or v[:release] == '6'
-            it 'should fail' do
-              expect {
-                should contain_class('pam')
-              }.to raise_error(Puppet::Error,/Pam is only supported with vas_major_version 3 or 4/)
-            end
-          else
-            it 'should fail' do
-              expect {
-                should contain_class('pam')
-              }.to raise_error(Puppet::Error,/Pam is only supported with vas_major_version 4 on EL7/)
-            end
-          end
+        it 'should fail' do
+          expect {
+            should contain_class('pam')
+          }.to raise_error(Puppet::Error,/expects a match for Enum\['3', '4'\]/)
         end
       end
     end
@@ -781,7 +771,7 @@ describe 'pam' do
         it 'should fail' do
           expect {
             should contain_class('pam')
-          }.to raise_error(Puppet::Error,/pam::login_pam_access is <invalid> and must be either 'required', 'requisite', 'sufficient', 'optional' or 'absent'./)
+          }.to raise_error(Puppet::Error,/Enum\['absent', 'optional', 'required', 'requisite', 'sufficient'\]/)
         end
       end
 
@@ -797,7 +787,7 @@ describe 'pam' do
         it 'should fail' do
           expect {
             should contain_class('pam')
-          }.to raise_error(Puppet::Error,/pam::sshd_pam_access is <invalid> and must be either 'required', 'requisite', 'sufficient', 'optional' or 'absent'./)
+          }.to raise_error(Puppet::Error,/Enum\['absent', 'optional', 'required', 'requisite', 'sufficient'\]/)
         end
       end
 
@@ -826,7 +816,7 @@ describe 'pam' do
         it 'should fail' do
           expect {
             should contain_class('pam')
-          }.to raise_error(Puppet::Error,/is not a boolean/)
+          }.to raise_error(Puppet::Error,/expects a Boolean value/)
         end
       end
 
@@ -841,7 +831,7 @@ describe 'pam' do
         it 'should fail' do
           expect {
             should contain_class('pam')
-          }.to raise_error(Puppet::Error,/Unknown type of boolean given/)
+          }.to raise_error(Puppet::Error,/expects a Boolean value/)
         end
       end
 
@@ -855,33 +845,18 @@ describe 'pam' do
         it { is_expected.to contain_class('nsswitch') }
       end
 
-      ['true', true, 'y'].each do |value|
-        context "with manage_nsswitch parameter set to #{value}" do
-          let :facts do
-            { :osfamily => v[:osfamily],
-              :"#{v[:releasetype]}" => v[:release],
-              :lsbdistid => v[:lsbdistid],
-            }
-          end
-          let(:params) { {:manage_nsswitch => value} }
-          it { is_expected.to contain_class('nsswitch') }
+      context "with manage_nsswitch parameter set to false" do
+        let :facts do
+          { :osfamily => v[:osfamily],
+            :"#{v[:releasetype]}" => v[:release],
+            :lsbdistid => v[:lsbdistid],
+          }
         end
+        let(:params) { {:manage_nsswitch => false} }
+        it { is_expected.not_to contain_class('nsswitch') }
       end
 
-      ['false', false, 'n'].each do |value|
-        context "with manage_nsswitch parameter set to #{value}" do
-          let :facts do
-            { :osfamily => v[:osfamily],
-              :"#{v[:releasetype]}" => v[:release],
-              :lsbdistid => v[:lsbdistid],
-            }
-          end
-          let(:params) { {:manage_nsswitch => value} }
-          it { is_expected.not_to contain_class('nsswitch') }
-        end
-      end
-
-      ['true',true,'false',false].each do |value|
+      [true,false].each do |value|
         context "with limits_fragments_hiera_merge parameter specified as a valid value: #{value} on #{v[:osfamily]} with #{v[:releasetype]} #{v[:release]}" do
           let :facts do
             { :osfamily => v[:osfamily],
@@ -962,7 +937,7 @@ describe 'pam' do
         :params  => { :pam_d_sshd_template => 'pam/sshd.custom.erb', :pam_sshd_auth_lines => ['#'], :pam_sshd_account_lines => ['#'], :pam_sshd_password_lines => ['#'], :pam_sshd_session_lines => ['#']},
         :valid   => [%w(array)],
         :invalid => ['string', { 'ha' => 'sh' }, 3, 2.42, true, false],
-        :message => 'is not an Array',
+        :message => 'expects a value of type Undef or Array',
       },
     }
 

--- a/spec/classes/limits_spec.rb
+++ b/spec/classes/limits_spec.rb
@@ -132,7 +132,7 @@ describe 'pam::limits' do
       it 'should fail' do
         expect {
           should contain_class('pam::limits')
-        }.to raise_error(Puppet::Error,/is not an Array.  It looks to be a String/)
+        }.to raise_error(Puppet::Error,/Array/)
       end
 
     end
@@ -182,7 +182,7 @@ describe 'pam::limits' do
       it 'should fail' do
         expect {
           should contain_class('pam::limits')
-        }.to raise_error(Puppet::Error,/not an absolute path/)
+        }.to raise_error(Puppet::Error,/Evaluation Error: Error while evaluating a Resource Statement/)
       end
     end
 
@@ -198,7 +198,7 @@ describe 'pam::limits' do
       it 'should fail' do
         expect {
           should contain_class('pam::limits')
-        }.to raise_error(Puppet::Error,/pam::limits::config_file_mode is <666> and must be a valid four digit mode in octal notation./)
+        }.to raise_error(Puppet::Error,/expects a match for Pattern\[\/\^\[0-7\]\{4\}\$\/\]/)
       end
     end
   end
@@ -263,7 +263,7 @@ describe 'pam::limits' do
       }
     end
 
-    [true,'true'].each do |value|
+    [true,false].each do |value|
       context "with purge_limits_d_dir set to #{value}" do
         let(:params) { { :purge_limits_d_dir => value } }
         let(:facts) do
@@ -280,33 +280,8 @@ describe 'pam::limits' do
             'owner'   => 'root',
             'group'   => 'root',
             'mode'    => '0750',
-            'purge'   => 'true',
-            'recurse' => 'true',
-            'require' => [ 'Package[pam]', 'Package[util-linux]', 'Common::Mkdir_p[/etc/security/limits.d]' ],
-          })
-        }
-      end
-    end
-
-    [false,'false'].each do |value|
-      context "with purge_limits_d_dir set to #{value}" do
-        let(:params) { { :purge_limits_d_dir => value } }
-        let(:facts) do
-          {
-            :osfamily                  => 'RedHat',
-            :operatingsystemmajrelease => '5',
-          }
-        end
-
-        it {
-          should contain_file('limits_d').with({
-            'ensure'  => 'directory',
-            'path'    => '/etc/security/limits.d',
-            'owner'   => 'root',
-            'group'   => 'root',
-            'mode'    => '0750',
-            'purge'   => 'false',
-            'recurse' => 'false',
+            'purge'   => value,
+            'recurse' => value,
             'require' => [ 'Package[pam]', 'Package[util-linux]', 'Common::Mkdir_p[/etc/security/limits.d]' ],
           })
         }
@@ -325,7 +300,7 @@ describe 'pam::limits' do
       it 'should fail' do
         expect {
           should contain_class('pam::limits')
-        }.to raise_error(Puppet::Error,/not an absolute path/)
+        }.to raise_error(Puppet::Error,/Evaluation Error: Error while evaluating a Resource Statement/)
       end
     end
 
@@ -341,7 +316,7 @@ describe 'pam::limits' do
       it 'should fail' do
         expect {
           should contain_class('pam::limits')
-        }.to raise_error(Puppet::Error,/pam::limits::limits_d_dir_mode is <777> and must be a valid four digit mode in octal notation./)
+        }.to raise_error(Puppet::Error,/expects a match for Pattern\[\/\^\[0-7\]\{4\}\$\/\]/)
       end
     end
 
@@ -357,7 +332,7 @@ describe 'pam::limits' do
       it 'should fail' do
         expect {
           should contain_class('pam::limits')
-        }.to raise_error(Puppet::Error,/str2bool/)
+        }.to raise_error(Puppet::Error,/expects a Boolean value/)
       end
     end
 

--- a/spec/defines/limits/fragment_spec.rb
+++ b/spec/defines/limits/fragment_spec.rb
@@ -166,7 +166,7 @@ root soft nproc unlimited
     it 'should fail' do
       expect {
         should contain_class('pam::limits')
-      }.to raise_error(Puppet::Error,/pam::limits::fragment::ensure <installed> and must be either 'file', 'present' or 'absent'./)
+      }.to raise_error(Puppet::Error,/match for Enum\[\'absent\', \'file\', \'present\'\]/)
     end
   end
 


### PR DESCRIPTION
This PR is incomplete, I have not updated the main pam class.  I wanted to know, should things that currently accept string or boolean and use str2bool be continued or should the data type just be Boolean?  These changes likely require a major version bump so figured maybe good time to force parameters to be the proper data type.