### PR TITLE
Replacing lsb* facts for SuSE distros

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -231,7 +231,7 @@ class pam (
           }
         }
         'Suse': {
-          case $::lsbmajdistrelease {
+          case $::operatingsystemmajrelease {
             '9': {
 
               file { 'pam_other':
@@ -442,7 +442,7 @@ class pam (
               }
             }
             default : {
-              fail("Pam is only supported on Suse 9, 10, 11, 12 and 13. Your lsbmajdistrelease is identified as <${::lsbmajdistrelease}>.")
+              fail("Pam is only supported on Suse 9, 10, 11, 12 and 13. Your operatingsystemmajrelease is identified as <${::operatingsystemmajrelease}}>.")
             }
           }
         }

--- a/manifests/limits.pp
+++ b/manifests/limits.pp
@@ -27,7 +27,7 @@ class pam::limits (
     $content = template('pam/limits.conf.erb')
     $config_file_source_real = undef
   }
-  if $::osfamily == 'Suse' and $::lsbmajdistrelease == '10'  {
+  if $::osfamily == 'Suse' and $::operatingsystemmajrelease == '10'  {
   } else {
     common::mkdir_p { $limits_d_dir: }
     file { 'limits_d':

--- a/manifests/limits/fragment.pp
+++ b/manifests/limits/fragment.pp
@@ -12,7 +12,7 @@ define pam::limits::fragment (
   include ::pam
   include ::pam::limits
 
-  if $::osfamily == 'Suse' and $::lsbmajdistrelease == '10' {
+  if $::osfamily == 'Suse' and $::operatingsystemmajrelease == '10' {
     fail('You can not use pam::limits::fragment together with Suse 10.x releases')
   }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -75,7 +75,7 @@ describe 'pam' do
       {
         :facts_hash => {
           :osfamily => 'Suse',
-          :lsbmajdistrelease => '9',
+          :operatingsystemmajrelease => '9',
           :os => {
             "name" => "openSUSE",
             "family" => "Suse",
@@ -96,7 +96,7 @@ describe 'pam' do
       {
         :facts_hash => {
           :osfamily => 'Suse',
-          :lsbmajdistrelease => '10',
+          :operatingsystemmajrelease => '10',
           :os => {
             "name" => "openSUSE",
             "family" => "Suse",
@@ -117,7 +117,7 @@ describe 'pam' do
       {
         :facts_hash => {
           :osfamily => 'Suse',
-          :lsbmajdistrelease => '11',
+          :operatingsystemmajrelease => '11',
           :os => {
             "name" => "openSUSE",
             "family" => "Suse",
@@ -140,7 +140,7 @@ describe 'pam' do
       {
         :facts_hash => {
           :osfamily => 'Suse',
-          :lsbmajdistrelease => '12',
+          :operatingsystemmajrelease => '12',
           :os => {
             "name" => "openSUSE",
             "family" => "Suse",
@@ -163,7 +163,7 @@ describe 'pam' do
       {
         :facts_hash => {
           :osfamily => 'Suse',
-          :lsbmajdistrelease => '13',
+          :operatingsystemmajrelease => '13',
           :os => {
             "name" => "openSUSE",
             "family" => "Suse",
@@ -395,7 +395,7 @@ describe 'pam' do
       {
         :facts_hash => {
           :osfamily => 'Suse',
-          :lsbmajdistrelease => '8',
+          :operatingsystemmajrelease => '8',
           :os => {
             "name" => "openSUSE",
             "family" => "Suse",

--- a/spec/classes/limits_spec.rb
+++ b/spec/classes/limits_spec.rb
@@ -466,7 +466,7 @@ describe 'pam::limits' do
       let(:facts) do
         {
           :osfamily          => 'Suse',
-          :lsbmajdistrelease => '10',
+          :operatingsystemmajrelease => '10',
           :os                 => {
             "name" => "openSUSE",
             "family" => "Suse",

--- a/spec/defines/limits/fragment_spec.rb
+++ b/spec/defines/limits/fragment_spec.rb
@@ -254,7 +254,7 @@ root soft nproc unlimited
     let(:facts) {
       {
         :osfamily               => 'Suse',
-        :lsbmajdistrelease      => '10',
+        :operatingsystemmajrelease => '10',
         :os                     => {
           "name" => "openSUSE",
           "family" => "Suse",


### PR DESCRIPTION
Hi,
This is related to issue #168 . Fixed for SuSE distros. There are some other lsb* facts for Debian/Ubuntu for which I'm not sure. Nevertheless I can test this on SLES 11 and 12

Best regards,