### PR TITLE
Adding a define that manages generic access files for other services …

### DIFF
--- a/manifests/genericaccess.pp
+++ b/manifests/genericaccess.pp
@@ -1,0 +1,26 @@
+# == Define: pam::genericaccess
+#
+# Manage access for any service
+#
+# See PAM_ACCESS(8)
+#
+define pam::genericaccess (
+  $genericaccess_conf_path     = "/etc/security/${name}.conf",
+  $genericaccess_conf_owner    = 'root',
+  $genericaccess_conf_group    = 'root',
+  $genericaccess_conf_mode     = '0644',
+  $genericaccess_conf_template = 'pam/genericaccess.conf.erb',
+  $genericaccess_conf_allow    = undef,
+) {
+
+  require '::pam'
+
+  file { "${name}_access_conf":
+    ensure  => file,
+    path    => $genericaccess_conf_path,
+    content => template($genericaccess_conf_template),
+    owner   => $genericaccess_conf_owner,
+    group   => $genericaccess_conf_group,
+    mode    => $genericaccess_conf_mode,
+  }
+}

--- a/templates/genericaccess.conf.erb
+++ b/templates/genericaccess.conf.erb
@@ -1,0 +1,25 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+#
+
+# allow only the groups listed
+<%
+entries = @genericaccess_conf_allow
+-%>
+<% if entries.is_a? Hash -%>
+<% entries.keys.sort.each do |key| -%>
+<% value = entries[key] -%>
++ : <%= key %> : <% if value.is_a? Array -%><%= value.join(' ') %><% elsif value.is_a? String -%><%= value %><% else -%>ALL<% end %>
+<% end -%>
+<% elsif entries.is_a? Array -%>
+<% entries.each do |key| -%>
++ : <%= key %> : ALL
+<% end -%>
+<% elsif entries.is_a? String -%>
++ : <%= entries %> : ALL
+<% else -%>
++ : root : ALL
+<% end -%>
+
+# default deny
+- : ALL : ALL


### PR DESCRIPTION
…than access

In case you want custom access files for other services:
/etc/pam.d/postgresql content : 
`[...]
account required pam_access.so accessfile=/etc/security/postgresql_access.conf
[...]`
this define lets you create the access file. 
