### PR TITLE
Add support for Debian 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,12 @@ matrix:
     env: BEAKER_set="debian-9" BEAKER_PUPPET_COLLECTION=puppet6
     bundler_args:
     script: bundle exec rake beaker
+  - rvm: 2.4.4
+    sudo: required
+    services: docker
+    env: BEAKER_set="debian-10" BEAKER_PUPPET_COLLECTION=puppet5
+    bundler_args:
+    script: bundle exec rake beaker
   - rvm: 2.5.3
     sudo: required
     services: docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,12 @@ matrix:
     env: BEAKER_set="debian-9" BEAKER_PUPPET_COLLECTION=puppet6
     bundler_args:
     script: bundle exec rake beaker
+  - rvm: 2.5.3
+    sudo: required
+    services: docker
+    env: BEAKER_set="debian-10" BEAKER_PUPPET_COLLECTION=puppet6
+    bundler_args:
+    script: bundle exec rake beaker
   - rvm: 2.4.4
     sudo: required
     services: docker

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ module aims to support the current and previous major Puppet versions.
  * EL 7
  * Debian 8
  * Debian 9
+ * Debian 10
  * Ubuntu 14.04 LTS
  * Ubuntu 16.04 LTS
  * Ubuntu 18.04 LTS

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,6 +57,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     c.vm.provision :shell, :inline => "puppet apply /vagrant/tests/init.pp"
   end
 
+  config.vm.define "debian10-pam", autostart: false do |c|
+    c.vm.box = "debian/buster64"
+    c.vm.hostname = 'debian10-pam.example.com'
+    c.vm.provision :shell, :path => "tests/provision_basic_debian.sh"
+    c.vm.provision :shell, :inline => "puppet apply /vagrant/tests/init.pp"
+  end
+
   config.vm.define "ubuntu1604-pam", autostart: false do |c|
     c.vm.box = "ubuntu/xenial64"
     c.vm.hostname = 'ubuntu1604-pam.example.com'

--- a/data/os/Debian/10.yaml
+++ b/data/os/Debian/10.yaml
@@ -1,0 +1,32 @@
+---
+pam::common_files_create_links: false
+pam::common_files_suffix:       ~
+pam::common_files:
+  - common_account
+  - common_auth
+  - common_password
+  - common_session
+  - common_session_noninteractive
+
+pam::pam_d_login_template: pam/login.debian9.erb
+pam::pam_d_sshd_template: pam/sshd.debian9.erb
+pam::package_name: libpam0g
+pam::pam_auth_lines:
+  - 'auth  [success=1 default=ignore]  pam_unix.so nullok_secure'
+  - 'auth  requisite   pam_deny.so'
+  - 'auth  required    pam_permit.so'
+pam::pam_account_lines:
+  - 'account [success=1 new_authtok_reqd=done default=ignore]  pam_unix.so'
+  - 'account requisite     pam_deny.so'
+  - 'account required      pam_permit.so'
+pam::pam_password_lines:
+  - 'password  [success=1 default=ignore]  pam_unix.so obscure sha512'
+  - 'password  requisite     pam_deny.so'
+  - 'password  required      pam_permit.so'
+pam::pam_session_lines:
+  - 'session [default=1]   pam_permit.so'
+  - 'session requisite     pam_deny.so'
+  - 'session required      pam_permit.so'
+  - 'session required      pam_unix.so'
+  - 'session optional      pam_systemd.so'
+

--- a/data/os/Debian/10.yaml
+++ b/data/os/Debian/10.yaml
@@ -29,4 +29,3 @@ pam::pam_session_lines:
   - 'session required      pam_permit.so'
   - 'session required      pam_unix.so'
   - 'session optional      pam_systemd.so'
-

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -247,8 +247,8 @@ class pam (
     fail("osfamily Solaris' kernelrelease is <${facts['kernelrelease']}> and must be 5.9, 5.10 or 5.11")
   } elsif $facts['os']['family'] == 'Suse' and !($facts['os']['release']['major'] in ['9','10','11','12','13','15']) {
     fail("osfamily Suse's os.release.major is <${::facts['os']['release']['major']}> and must be 9, 10, 11, 12, 13 or 15")
-  } elsif $facts['os']['name'] == 'Debian' and !($facts['os']['release']['major'] in ['7','8','9']) {
-    fail("Debian's os.release.major is <${facts['os']['release']['major']}> and must be 7, 8 or 9")
+  } elsif $facts['os']['name'] == 'Debian' and !($facts['os']['release']['major'] in ['7','8','9','10']) {
+    fail("Debian's os.release.major is <${facts['os']['release']['major']}> and must be 7, 8, 9 or 10")
   } elsif $facts['os']['name'] == 'Ubuntu' and !($facts['os']['release']['major'] in ['12.04', '14.04', '16.04', '18.04']) {
     fail("Ubuntu's os.release.major is <${facts['os']['release']['major']}> and must be 12.04, 14.04, 16.04, or 18.04")
   }

--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,8 @@
       "operatingsystemrelease": [
         "7",
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {

--- a/spec/acceptance/nodesets/debian-10.yml
+++ b/spec/acceptance/nodesets/debian-10.yml
@@ -1,0 +1,24 @@
+HOSTS:
+  debian10:
+    roles:
+    - agent
+    platform: debian-10-amd64
+    hypervisor: docker
+    image: debian:10
+    docker_preserve_image: true
+    docker_cmd:
+    - '/sbin/init'
+    docker_image_commands:
+    - 'apt-get install -y wget net-tools systemd-sysv locales'
+    - 'rm -f /usr/sbin/policy-rc.d'
+    - 'echo "LC_ALL=en_US.UTF-8" >> /etc/environment'
+    - 'echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen'
+    - 'echo "LANG=en_US.UTF-8" > /etc/locale.conf'
+    - 'locale-gen en_US.UTF-8'
+    docker_container_name: 'pam-debian10'
+CONFIG:
+  log_level: debug
+  type: foss
+ssh:
+  password: root
+  auth_methods: ["password"]

--- a/spec/fixtures/pam_common_account.defaults.debian10
+++ b/spec/fixtures/pam_common_account.defaults.debian10
@@ -1,0 +1,5 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+account [success=1 new_authtok_reqd=done default=ignore]  pam_unix.so
+account requisite     pam_deny.so
+account required      pam_permit.so

--- a/spec/fixtures/pam_common_auth.defaults.debian10
+++ b/spec/fixtures/pam_common_auth.defaults.debian10
@@ -1,0 +1,5 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+auth  [success=1 default=ignore]  pam_unix.so nullok_secure
+auth  requisite     pam_deny.so
+auth  required      pam_permit.so

--- a/spec/fixtures/pam_common_password.defaults.debian10
+++ b/spec/fixtures/pam_common_password.defaults.debian10
@@ -1,0 +1,5 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+password  [success=1 default=ignore]  pam_unix.so obscure sha512
+password  requisite     pam_deny.so
+password  required      pam_permit.so

--- a/spec/fixtures/pam_common_session.defaults.debian10
+++ b/spec/fixtures/pam_common_session.defaults.debian10
@@ -1,0 +1,7 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+session [default=1]   pam_permit.so
+session requisite     pam_deny.so
+session required      pam_permit.so
+session required      pam_unix.so
+session optional      pam_systemd.so

--- a/spec/fixtures/pam_common_session_noninteractive.defaults.debian10
+++ b/spec/fixtures/pam_common_session_noninteractive.defaults.debian10
@@ -1,0 +1,7 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+session [default=1]   pam_permit.so
+session requisite     pam_deny.so
+session required      pam_permit.so
+session required      pam_unix.so
+session optional      pam_systemd.so

--- a/spec/fixtures/pam_d_login.defaults.debian10
+++ b/spec/fixtures/pam_d_login.defaults.debian10
@@ -1,0 +1,19 @@
+auth       optional   pam_faildelay.so  delay=3000000
+auth [success=ok new_authtok_reqd=ok ignore=ignore user_unknown=bad default=die] pam_securetty.so
+auth       requisite  pam_nologin.so
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so close
+session    required     pam_loginuid.so
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so open
+session       required   pam_env.so readenv=1
+session       required   pam_env.so readenv=1 envfile=/etc/default/locale
+@include common-auth
+auth       optional   pam_group.so
+session    required   pam_limits.so
+session    optional   pam_lastlog.so
+session    optional   pam_motd.so motd=/run/motd.dynamic
+session    optional   pam_motd.so noupdate
+session    optional   pam_mail.so standard
+session    optional   pam_keyinit.so force revoke
+@include common-account
+@include common-session
+@include common-password

--- a/spec/fixtures/pam_d_sshd.defaults.debian10
+++ b/spec/fixtures/pam_d_sshd.defaults.debian10
@@ -1,0 +1,13 @@
+@include common-auth
+account    required     pam_nologin.so
+account  required     pam_access.so
+@include common-account
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so close
+session    required     pam_loginuid.so
+session    optional     pam_keyinit.so force revoke
+@include common-session
+session    optional     pam_motd.so  motd=/run/motd.dynamic
+session    optional     pam_motd.so noupdate
+session    required     pam_limits.so
+session    required     pam_env.so user_readenv=1 envfile=/etc/default/locale
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so open

--- a/spec/fixtures/pam_d_sshd.defaults.debian10
+++ b/spec/fixtures/pam_d_sshd.defaults.debian10
@@ -11,3 +11,4 @@ session    optional     pam_motd.so noupdate
 session    required     pam_limits.so
 session    required     pam_env.so user_readenv=1 envfile=/etc/default/locale
 session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so open
+@include common-password

--- a/templates/login.debian10.erb
+++ b/templates/login.debian10.erb
@@ -1,0 +1,19 @@
+auth       optional   pam_faildelay.so  delay=3000000
+auth [success=ok new_authtok_reqd=ok ignore=ignore user_unknown=bad default=die] pam_securetty.so
+auth       requisite  pam_nologin.so
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so close
+session    required     pam_loginuid.so
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so open
+session       required   pam_env.so readenv=1
+session       required   pam_env.so readenv=1 envfile=/etc/default/locale
+@include common-auth
+auth       optional   pam_group.so
+session    required   pam_limits.so
+session    optional   pam_lastlog.so
+session    optional   pam_motd.so motd=/run/motd.dynamic
+session    optional   pam_motd.so noupdate
+session    optional   pam_mail.so standard
+session    optional   pam_keyinit.so force revoke
+@include common-account
+@include common-session
+@include common-password

--- a/templates/sshd.debian10.erb
+++ b/templates/sshd.debian10.erb
@@ -1,0 +1,18 @@
+@include common-auth
+account    required     pam_nologin.so
+<% if @sshd_pam_access != 'absent' -%>
+account  <%= @sshd_pam_access %>     pam_access.so
+<% end -%>
+@include common-account
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so close
+session    required     pam_loginuid.so
+session    optional     pam_keyinit.so force revoke
+@include common-session
+session    optional     pam_motd.so  motd=/run/motd.dynamic
+session    optional     pam_motd.so noupdate
+session    optional     pam_mail.so standard noenv # [1]
+session    required     pam_limits.so
+session    required     pam_env.so # [1]
+session    required     pam_env.so user_readenv=1 envfile=/etc/default/locale
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so open
+

--- a/templates/sshd.debian10.erb
+++ b/templates/sshd.debian10.erb
@@ -15,3 +15,4 @@ session    required     pam_limits.so
 session    required     pam_env.so # [1]
 session    required     pam_env.so user_readenv=1 envfile=/etc/default/locale
 session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so open
+@include common-password

--- a/templates/sshd.debian10.erb
+++ b/templates/sshd.debian10.erb
@@ -15,4 +15,3 @@ session    required     pam_limits.so
 session    required     pam_env.so # [1]
 session    required     pam_env.so user_readenv=1 envfile=/etc/default/locale
 session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so open
-


### PR DESCRIPTION
There ist currently no package for a puppet5 puppetserver on Debian 10, so I added travis tests only for puppet6.