### PR TITLE
add amazon linux 2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ module aims to support the current and previous major Puppet versions.
 These platforms have spec tests and have been verified in the past,
 though are not functionally tested and formally supported.
 
+ * Amazon Linux 2
  * EL 8
  * EL 5
  * Solaris 9

--- a/data/os/Amazon/2.yaml
+++ b/data/os/Amazon/2.yaml
@@ -1,0 +1,44 @@
+---
+pam::common_files_create_links: false
+pam::common_files_suffix:       ~
+pam::common_files:
+  - password_auth
+  - system_auth
+
+pam::pam_d_login_template: pam/login.el2.erb
+pam::pam_d_sshd_template: pam/sshd.el2.erb
+
+pam::package_name: pam
+
+pam::pam_auth_lines:
+  - 'auth        required      pam_env.so'
+  - 'auth        sufficient    pam_unix.so try_first_pass nullok'
+  - 'auth        required      pam_deny.so'
+pam::pam_password_auth_lines:
+  - 'auth        required      pam_env.so'
+  - 'auth        sufficient    pam_unix.so try_first_pass nullok'
+  - 'auth        required      pam_deny.so'
+pam::pam_account_lines:
+  - 'account     required      pam_unix.so'
+pam::pam_password_account_lines:
+  - 'account     required      pam_unix.so'
+pam::pam_password_lines:
+  - 'password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type='
+  - 'password    sufficient    pam_unix.so try_first_pass use_authtok nullok sha512 shadow'
+  - 'password    required      pam_deny.so'
+pam::pam_password_password_lines:
+  - 'password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type='
+  - 'password    sufficient    pam_unix.so try_first_pass use_authtok nullok sha512 shadow'
+  - 'password    required      pam_deny.so'
+pam::pam_session_lines:
+  - 'session     optional      pam_keyinit.so revoke'
+  - 'session     required      pam_limits.so'
+  - '-session     optional      pam_systemd.so'
+  - 'session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid'
+  - 'session     required      pam_unix.so'
+pam::pam_password_session_lines:
+  - 'session     optional      pam_keyinit.so revoke'
+  - 'session     required      pam_limits.so'
+  - '-session     optional      pam_systemd.so'
+  - 'session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid'
+  - 'session     required      pam_unix.so'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -241,8 +241,8 @@ class pam (
 ) {
 
   # Fail on unsupported platforms
-  if $facts['os']['family'] == 'RedHat' and !($facts['os']['release']['major'] in ['5','6','7','8']) {
-    fail("osfamily RedHat's os.release.major is <${::facts['os']['release']['major']}> and must be 5, 6, 7 or 8")
+  if $facts['os']['family'] == 'RedHat' and !($facts['os']['release']['major'] in ['2','5','6','7','8']) {
+    fail("osfamily RedHat's os.release.major is <${::facts['os']['release']['major']}> and must be 2, 5, 6, 7 or 8")
   } elsif $facts['os']['family'] == 'Solaris' and !($facts['kernelrelease'] in ['5.9','5.10','5.11']) {
     fail("osfamily Solaris' kernelrelease is <${facts['kernelrelease']}> and must be 5.9, 5.10 or 5.11")
   } elsif $facts['os']['family'] == 'Suse' and !($facts['os']['release']['major'] in ['9','10','11','12','13','15']) {

--- a/metadata.json
+++ b/metadata.json
@@ -16,6 +16,12 @@
   ],
   "operatingsystem_support": [
     {
+      "operatingsystem": "Amazon",
+      "operatingsystemrelease": [
+        "2"
+      ]
+    },
+    {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "7",

--- a/spec/fixtures/pam_d_login.defaults.el2
+++ b/spec/fixtures/pam_d_login.defaults.el2
@@ -1,0 +1,17 @@
+#%PAM-1.0
+auth       substack     system-auth
+auth       include      postlogin
+account    required     pam_nologin.so
+account    include      system-auth
+password   include      system-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+session    optional     pam_console.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open
+session    required     pam_namespace.so
+session    optional     pam_keyinit.so force revoke
+session    include      system-auth
+session    include      postlogin
+-session   optional     pam_ck_connector.so

--- a/spec/fixtures/pam_d_sshd.defaults.el2
+++ b/spec/fixtures/pam_d_sshd.defaults.el2
@@ -1,0 +1,20 @@
+#%PAM-1.0
+auth       required     pam_sepermit.so
+auth       substack     password-auth
+auth       include      postlogin
+# Used with polkit to reauthorize users in remote sessions
+-auth      optional     pam_reauthorize.so prepare
+account    required     pam_nologin.so
+account    include      password-auth
+password   include      password-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open env_params
+session    required     pam_namespace.so
+session    optional     pam_keyinit.so force revoke
+session    include      password-auth
+session    include      postlogin
+# Used with polkit to reauthorize users in remote sessions
+-session   optional     pam_reauthorize.so prepare

--- a/spec/fixtures/pam_password_auth_ac.defaults.el2
+++ b/spec/fixtures/pam_password_auth_ac.defaults.el2
@@ -1,0 +1,21 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+# Auth
+auth        required      pam_env.so
+auth        sufficient    pam_unix.so try_first_pass nullok
+auth        required      pam_deny.so
+
+# Account
+account     required      pam_unix.so
+
+# Password
+password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
+password    sufficient    pam_unix.so try_first_pass use_authtok nullok sha512 shadow
+password    required      pam_deny.so
+
+# Session
+session     optional      pam_keyinit.so revoke
+session     required      pam_limits.so
+-session     optional      pam_systemd.so
+session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
+session     required      pam_unix.so

--- a/spec/fixtures/pam_system_auth_ac.defaults.el2
+++ b/spec/fixtures/pam_system_auth_ac.defaults.el2
@@ -1,0 +1,21 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+# Auth
+auth        required      pam_env.so
+auth        sufficient    pam_unix.so try_first_pass nullok
+auth        required      pam_deny.so
+
+# Account
+account     required      pam_unix.so
+
+# Password
+password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
+password    sufficient    pam_unix.so try_first_pass use_authtok nullok sha512 shadow
+password    required      pam_deny.so
+
+# Session
+session     optional      pam_keyinit.so revoke
+session     required      pam_limits.so
+-session     optional      pam_systemd.so
+session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
+session     required      pam_unix.so

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,27 @@ end
 
 def platforms
   {
+    'el2' =>
+      {
+        :facts_hash => {
+          :osfamily => 'RedHat',
+          :operatingsystem => 'Amazon',
+          :operatingsystemmajrelease => '2',
+          :os => {
+            'name' => 'Amazon',
+            'family' => 'RedHat',
+            'release' => {
+              'full'  => '2',
+              'major' => '2',
+            }
+          },
+        },
+        :packages           => ['pam', ],
+        :files              => [
+          { :prefix         => 'pam_',
+            :types          => ['system_auth', ],
+          }, ],
+      },
     'el5' =>
       {
         :facts_hash => {

--- a/templates/login.el2.erb
+++ b/templates/login.el2.erb
@@ -1,0 +1,20 @@
+#%PAM-1.0
+auth       substack     system-auth
+auth       include      postlogin
+account    required     pam_nologin.so
+account    include      system-auth
+<% if @login_pam_access != 'absent' -%>
+account    <%= @login_pam_access %>     pam_access.so
+<% end -%>
+password   include      system-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+session    optional     pam_console.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open
+session    required     pam_namespace.so
+session    optional     pam_keyinit.so force revoke
+session    include      system-auth
+session    include      postlogin
+-session   optional     pam_ck_connector.so

--- a/templates/sshd.el2.erb
+++ b/templates/sshd.el2.erb
@@ -1,0 +1,23 @@
+#%PAM-1.0
+auth       required     pam_sepermit.so
+auth       substack     password-auth
+auth       include      postlogin
+# Used with polkit to reauthorize users in remote sessions
+-auth      optional     pam_reauthorize.so prepare
+<% if @sshd_pam_access != 'absent' -%>
+account    <%= @sshd_pam_access %>     pam_access.so
+<% end -%>
+account    required     pam_nologin.so
+account    include      password-auth
+password   include      password-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open env_params
+session    required     pam_namespace.so
+session    optional     pam_keyinit.so force revoke
+session    include      password-auth
+session    include      postlogin
+# Used with polkit to reauthorize users in remote sessions
+-session   optional     pam_reauthorize.so prepare


### PR DESCRIPTION
Adds Amazon Linux 2 support based off of the baseline values of the Amazon Linux 2 AMI.