### PR TITLE
Missing entries in pam.d/sshd for Ubuntu 16

### DIFF
--- a/spec/fixtures/pam_d_sshd.defaults.ubuntu1604
+++ b/spec/fixtures/pam_d_sshd.defaults.ubuntu1604
@@ -8,7 +8,9 @@ session  optional     pam_keyinit.so force revoke
 @include common-session
 session  optional     pam_motd.so  motd=/run/motd.dynamic
 session  optional     pam_motd.so  noupdate
+session  optional     pam_mail.so standard noenv # [1]
 session  required     pam_limits.so
+session  required     pam_env.so # [1]
 session  required     pam_env.so user_readenv=1 envfile=/etc/default/locale
 session  [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so open
 @include common-password

--- a/templates/sshd.ubuntu16.erb
+++ b/templates/sshd.ubuntu16.erb
@@ -11,6 +11,7 @@ session  optional     pam_keyinit.so force revoke
 session  optional     pam_motd.so  motd=/run/motd.dynamic
 session  optional     pam_motd.so  noupdate
 session  required     pam_limits.so
+session  required     pam_env.so # [1]
 session  required     pam_env.so user_readenv=1 envfile=/etc/default/locale
 session  [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so open
 @include common-password

--- a/templates/sshd.ubuntu16.erb
+++ b/templates/sshd.ubuntu16.erb
@@ -10,6 +10,7 @@ session  optional     pam_keyinit.so force revoke
 @include common-session
 session  optional     pam_motd.so  motd=/run/motd.dynamic
 session  optional     pam_motd.so  noupdate
+session  optional     pam_mail.so standard noenv # [1]
 session  required     pam_limits.so
 session  required     pam_env.so # [1]
 session  required     pam_env.so user_readenv=1 envfile=/etc/default/locale


### PR DESCRIPTION
The /etc/pam.d/sshd file generated for Ubuntu 16.04 are missing these two lines compared to default:

```bash
# Print the status of the user's mailbox upon successful login.
session    optional     pam_mail.so standard noenv # [1]

# Read environment variables from /etc/environment and
# /etc/security/pam_env.conf.
session    required     pam_env.so # [1]
```

This PR fixes this.

Templates for Ubuntu 18 and Ubuntu 20 are already ok.



